### PR TITLE
docs: document seemingly necessary eslint.validate config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ You can install this extension from the [Marketplace](https://marketplace.visual
     "extensions": [".js", ".jsx", ".md", ".mdx", ".ts", ".tsx"]
   },
   "eslint.validate": [
+    "markdown",
+    "mdx",
     "javascript",
     "javascriptreact",
     "typescript",
-    "typescriptreact",
-    "mdx"
+    "typescriptreact"
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ You can install this extension from the [Marketplace](https://marketplace.visual
   },
   "eslint.options": {
     "extensions": [".js", ".jsx", ".md", ".mdx", ".ts", ".tsx"]
-  }
+  },
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "mdx"
+  ]
 }
 ```
 


### PR DESCRIPTION
I installed version 0.2.2 of this extension, alongside VSCode ESLint 2.1.14 on VSCode 1.53.2.  I have eslint 7.20.0 and eslint-plugin-mdx 1.8.2.  Running eslint from the command line reported violations as expected.  However, VSCode refused to show squiggly red lines under eslint violations in an `.mdx` file until I added this "eslint.validate" config in addition to the above suggested config.

The array elements preceding "mdx" are the default values - without them you'll break validation elsewhere


