### PR TITLE
chore: update extension metadata content and README

### DIFF
--- a/.changeset/sixty-geckos-design.md
+++ b/.changeset/sixty-geckos-design.md
@@ -1,0 +1,5 @@
+---
+"vscode-mdx": patch
+---
+
+chore: update extension metadata content and README

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,6 @@
   "overrides": [
     {
       "files": [
-        ".github/*.yml",
         "syntaxes/*.json"
       ],
       "rules": {

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "@1stg/preset"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
-# [Visual Studio Code](https://code.visualstudio.com) extension for [MDX]
+# [Visual Studio Code](https://code.visualstudio.com) extension for [MDX][]
 
 [![GitHub Actions](https://github.com/mdx-js/vscode-mdx/workflows/CI/badge.svg)](https://github.com/mdx-js/vscode-mdx/actions/workflows/ci.yml)
 [![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/unifiedjs.vscode-mdx)](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx)
 [![GitHub release](https://img.shields.io/github/release/mdx-js/vscode-mdx)](https://github.com/mdx-js/vscode-mdx/releases)
 [![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/unifiedjs.vscode-mdx)](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx)
+[![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/mdx-js/vscode-mdx.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/mdx-js/vscode-mdx/context:javascript)
 
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com)
 [![Conventional Commits](https://img.shields.io/badge/conventional%20commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
-[![changesets](https://img.shields.io/badge/maintained%20with-changesets-cc00ff.svg)](https://github.com/changesets/changesets)
+[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com)
+[![Code Style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+[![changesets](https://img.shields.io/badge/maintained%20with-changesets-176de3.svg)](https://github.com/changesets/changesets)
 
-Adds language support for [MDX].
+Adds language support for [MDX][].
 
 ## Installation
 
@@ -76,7 +78,7 @@ Please add the following setting to use system default Node runtime instead:
 }
 ```
 
-Please visit https://github.com/microsoft/vscode-eslint/issues/1498#issuecomment-1175813839 as reference for details.
+Please visit <https://github.com/microsoft/vscode-eslint/issues/1498#issuecomment-1175813839> as reference for details.
 
 2. `JavaScript heap out of memory`
 
@@ -88,7 +90,7 @@ The default memory limit of Node.js is `1G`, please add the following setting to
 }
 ```
 
-Please visit https://github.com/microsoft/vscode-eslint/issues/733 as reference for details.
+Please visit <https://github.com/microsoft/vscode-eslint/issues/733> as reference for details.
 
 ## Sponsors
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "vscode-mdx",
   "version": "1.0.1",
-  "displayName": "VSCode MDX",
-  "description": "Visual Studio Code extension for MDX",
+  "displayName": "MDX",
+  "description": "Language support for MDX",
   "categories": [
     "Programming Languages"
   ],
@@ -141,5 +141,9 @@
         }
       }
     ]
+  },
+  "qna": "https://github.com/orgs/mdx-js/discussions",
+  "sponsor": {
+    "url": "https://github.com/mdx-js/vscode-mdx?sponsor=1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "type": "opencollective",
     "url": "https://opencollective.com/unified"
   },
+  "sponsor": {
+    "url": "https://github.com/mdx-js/vscode-mdx?sponsor=1"
+  },
   "license": "MIT",
   "private": true,
   "packageManager": "yarn@1.22.19",
@@ -60,12 +63,12 @@
     "prepare": "patch-package && simple-git-hooks && yarn-deduplicate --strategy fewer || exit 0"
   },
   "devDependencies": {
-    "@1stg/common-config": "^6.1.4",
+    "@1stg/common-config": "^7.0.0",
     "@changesets/changelog-github": "^0.4.6",
-    "@changesets/cli": "^2.24.2",
+    "@changesets/cli": "^2.24.3",
     "patch-package": "^6.4.7",
     "typescript": "^4.7.4",
-    "yarn-deduplicate": "^5.0.0"
+    "yarn-deduplicate": "^5.0.2"
   },
   "resolutions": {
     "prettier": "^2.7.1"
@@ -142,8 +145,5 @@
       }
     ]
   },
-  "qna": "https://github.com/orgs/mdx-js/discussions",
-  "sponsor": {
-    "url": "https://github.com/mdx-js/vscode-mdx?sponsor=1"
-  }
+  "qna": "https://github.com/orgs/mdx-js/discussions"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,23 +35,23 @@
     "@commitlint/config-lerna-scopes" "^17.0.2"
     "@pkgr/utils" "^2.3.0"
 
-"@1stg/common-config@^6.1.4":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@1stg/common-config/-/common-config-6.1.4.tgz#63a750e664e1e7138ffc2b15ee433303d7bce7d6"
-  integrity sha512-gbISGR1hqt5VlzqXnaG8y7hMz+GeD2whgKQ2RmopOGdHp2vXxm0rq7IOQWvAhz5m/MCSmIA9/0/o6c/lBQnbuA==
+"@1stg/common-config@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@1stg/common-config/-/common-config-7.0.0.tgz#a8da9447e987870686ce3af4fb3cd6ae6fea9e9e"
+  integrity sha512-OMY6N2b2Sn5XfmbfWkUPXrXzp51ZLBpKvzc2hAeTMkENgk3UgTjVbpc/EvrFUEPz2NuCDM8YFOS8OKBIWbR3lw==
   dependencies:
     "@1stg/babel-preset" "^3.1.4"
     "@1stg/commitlint-config" "^3.1.4"
-    "@1stg/eslint-config" "^5.4.4"
-    "@1stg/lint-staged" "^3.3.0"
+    "@1stg/eslint-config" "^5.5.0"
+    "@1stg/lint-staged" "^3.3.2"
     "@1stg/markuplint-config" "^2.2.0"
-    "@1stg/prettier-config" "^3.7.0"
-    "@1stg/remark-config" "^4.0.3"
+    "@1stg/prettier-config" "^3.8.0"
+    "@1stg/remark-preset" "^1.0.0"
     "@1stg/simple-git-hooks" "^0.2.1"
-    "@1stg/tsconfig" "^2.2.5"
-    "@babel/core" "^7.18.9"
+    "@1stg/tsconfig" "^2.3.0"
+    "@babel/core" "^7.18.10"
     "@commitlint/cli" "^17.0.3"
-    eslint "^8.20.0"
+    eslint "^8.22.0"
     lint-staged "^13.0.3"
     npm-run-all "^4.1.5"
     prettier "^2.7.1"
@@ -63,34 +63,34 @@
   resolved "https://registry.yarnpkg.com/@1stg/config/-/config-0.2.0.tgz#ab70456f7c3f13d3e82e9fe187e84a4882c32a75"
   integrity sha512-7PPr6ZCIh0KqbQSePoVtTO/apo3gjPkrWeM7EAJ8YwN4LJE3CDtYQ0bvF2t0c0zLhNYmGxqe64Z+8c98wzuqaw==
 
-"@1stg/eslint-config@^5.4.4":
-  version "5.4.4"
-  resolved "https://registry.yarnpkg.com/@1stg/eslint-config/-/eslint-config-5.4.4.tgz#3c0c742490bc8032bf403ff13b8d8ceac826af92"
-  integrity sha512-iAtf2Awz7KkUKYB+Qq0Tj514qrIKrIbhp0Dn3mYDcqmWiFkuzwebUOZVJg3miZXEnQc9w+0Vqlb6LczPVVrbCg==
+"@1stg/eslint-config@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@1stg/eslint-config/-/eslint-config-5.5.0.tgz#2fcf8630439e541953f0cc34423816852b7dbea4"
+  integrity sha512-ODIXPhLOkUJ5Szfu4l66n91OW6w1rDh5ltWIBI3UeS1btY9Gg/2wRkLwFG6+N1YYPvJeBGG0nLGWxMd27wodVg==
   dependencies:
     "@1stg/config" "^0.2.0"
     "@angular-eslint/eslint-plugin" "^14.0.2"
     "@angular-eslint/eslint-plugin-template" "^14.0.2"
     "@angular-eslint/template-parser" "^14.0.2"
     "@babel/eslint-parser" "^7.18.9"
-    "@babel/eslint-plugin" "^7.17.7"
+    "@babel/eslint-plugin" "^7.18.10"
     "@pkgr/utils" "^2.3.0"
-    "@typescript-eslint/eslint-plugin" "^5.30.7"
-    "@typescript-eslint/parser" "^5.30.7"
+    "@typescript-eslint/eslint-plugin" "^5.33.0"
+    "@typescript-eslint/parser" "^5.33.0"
     angular-eslint-template-parser "^0.1.1"
     eslint-config-prettier "^8.5.0"
     eslint-config-standard "^17.0.0"
     eslint-config-standard-jsx "^11.0.0"
     eslint-config-standard-react "^11.0.1"
     eslint-formatter-friendly "^7.0.0"
-    eslint-import-resolver-typescript "^3.3.0"
+    eslint-import-resolver-typescript "^3.4.1"
     eslint-plugin-css "^0.6.0"
     eslint-plugin-es-x "^5.2.1"
     eslint-plugin-eslint-comments "^3.2.0"
     eslint-plugin-import "npm:eslint-plugin-i@^2.26.0"
-    eslint-plugin-jest "^26.6.0"
-    eslint-plugin-jsdoc "^39.3.3"
-    eslint-plugin-json-schema-validator "^4.0.0"
+    eslint-plugin-jest "^26.8.2"
+    eslint-plugin-jsdoc "^39.3.6"
+    eslint-plugin-json-schema-validator "^4.0.1"
     eslint-plugin-jsonc "^2.3.1"
     eslint-plugin-markup "^0.10.1"
     eslint-plugin-mdx "^2.0.2"
@@ -99,24 +99,24 @@
     eslint-plugin-promise "^6.0.0"
     eslint-plugin-react "^7.30.1"
     eslint-plugin-react-hooks "^4.6.0"
-    eslint-plugin-regexp "^1.7.0"
+    eslint-plugin-regexp "^1.8.0"
     eslint-plugin-simple-import-sort "^7.0.0"
-    eslint-plugin-sonar "^0.8.0"
-    eslint-plugin-sonarjs "^0.14.0"
-    eslint-plugin-svelte "^2.2.0"
+    eslint-plugin-sonar "^0.9.0"
+    eslint-plugin-sonarjs "^0.15.0"
+    eslint-plugin-svelte "^2.5.0"
     eslint-plugin-toml "^0.3.1"
     eslint-plugin-unicorn "^43.0.2"
-    eslint-plugin-vue "^9.2.0"
-    eslint-plugin-yml "^1.0.0"
+    eslint-plugin-vue "^9.3.0"
+    eslint-plugin-yml "^1.1.0"
 
-"@1stg/lint-staged@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@1stg/lint-staged/-/lint-staged-3.3.0.tgz#a2aaa312e62d89d08d7912a3b7f2cce8f0e37f44"
-  integrity sha512-I4+1OWDoNgslnRhu/VbRgt+pkAoPb1DKBZWs5Ji5qq5+lr51c0Alw/mPJfXDPEICYdSuq6AqEZs29oe4bXxxig==
+"@1stg/lint-staged@^3.3.2":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@1stg/lint-staged/-/lint-staged-3.3.2.tgz#ec11635f831c439c938f7e0a25753496f9a1b761"
+  integrity sha512-A3ArWF2X6QZK0aQJLqdxS7QOxjcSrcIp2BzgxU4nmqVFlobNp/LPf4JTkwbagXCN0YBmE9cEhHCVbrfKfDCqnQ==
   dependencies:
     "@1stg/config" "^0.2.0"
-    "@1stg/prettier-config" "^3.7.0"
-    "@1stg/tsconfig" "^2.2.3"
+    "@1stg/prettier-config" "^3.8.0"
+    "@1stg/tsconfig" "^2.3.0"
     "@pkgr/utils" "^2.3.0"
     prettier "^2.7.1"
 
@@ -130,27 +130,27 @@
     "@markuplint/vue-spec" "^2.1.1"
     markuplint-angular-parser "^1.1.3"
 
-"@1stg/prettier-config@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@1stg/prettier-config/-/prettier-config-3.7.0.tgz#b6f5b722b08cc6b0a1ea2dd5bd50585b6894c0e8"
-  integrity sha512-rzqsEx79X06cTkx7dhRo8Aq4RPgHXrDVYAANtor+Xjtohc/nxsilLfOfypJz9Fsfeoijkq13eOdQaokpbDYu4w==
+"@1stg/prettier-config@^3.8.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@1stg/prettier-config/-/prettier-config-3.9.0.tgz#6ded0d4052c222bf6fb94958bdffd6c31ede5edd"
+  integrity sha512-TiTQlIXwwHpdxKrZhBPtBZV3/0cWdFqiQToXk/36c9HRr2coqG1z91S4NSlksTcjvvCxa8AZQQXrCxJcSWTGNA==
   dependencies:
     "@1stg/config" "^0.2.0"
-    "@prettier/plugin-pug" "^2.1.1"
-    "@prettier/plugin-ruby" "^3.1.2"
+    "@prettier/plugin-pug" "^2.2.0"
+    "@prettier/plugin-ruby" "^3.2.0"
     "@prettier/plugin-xml" "^2.2.0"
-    prettier-plugin-ini "^1.0.0"
-    prettier-plugin-pkg "^0.16.0"
-    prettier-plugin-properties "^0.1.0"
-    prettier-plugin-sh "^0.12.6"
-    prettier-plugin-stylus "^0.0.1-beta.3"
+    prettier-plugin-ini "^1.1.0"
+    prettier-plugin-pkg "^0.17.0"
+    prettier-plugin-properties "^0.2.0"
+    prettier-plugin-sh "^0.12.8"
+    prettier-plugin-stylus "^0.0.1-beta.8"
     prettier-plugin-svelte "^2.7.0"
     prettier-plugin-toml "^0.3.1"
 
-"@1stg/remark-config@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@1stg/remark-config/-/remark-config-4.0.3.tgz#c17956edb0acaa94ed52751751d1a900fc9a9bc3"
-  integrity sha512-gojIvUH/kybjHdOVSdWmYYnUuhJr4XVXzzGoJsgLQHEInRsGpVkj5+/T5iKsAvXcPzdMu0ITsgPR9Ox22z2Wdg==
+"@1stg/remark-preset@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@1stg/remark-preset/-/remark-preset-1.0.0.tgz#280605bc417ca2d2b90ab81fac6b69362004fc62"
+  integrity sha512-GVHBtf8O0Vv3d1Ykgj3k4fl+UfHOwJe/HUhPZwDQKlvlh2HqfhiJXmiX+urKMqd/CjH4yzdcscrKPO5eF4UauA==
   dependencies:
     remark-frontmatter "^4.0.1"
     remark-gfm "^3.0.1"
@@ -160,7 +160,7 @@
     remark-preset-lint-consistent "^5.1.1"
     remark-preset-lint-markdown-style-guide "^5.1.2"
     remark-preset-lint-recommended "^6.1.2"
-    remark-preset-prettier "^1.0.1"
+    remark-preset-prettier "^1.0.2"
     remark-validate-links "^12.0.0"
 
 "@1stg/simple-git-hooks@^0.2.1":
@@ -170,10 +170,10 @@
   dependencies:
     "@pkgr/utils" "^2.3.0"
 
-"@1stg/tsconfig@^2.2.3", "@1stg/tsconfig@^2.2.5":
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/@1stg/tsconfig/-/tsconfig-2.2.5.tgz#ac8d9fb5e5e7948cf4ea4ed047d285da30eb0eca"
-  integrity sha512-HGu7fJHp+5vLeXH7R/AozA2VtjtE/KACv2bhAA0Hrtk2fX2OE0xNynb/tg31kTRU8cStEmlMLKxAexdv7BPYPA==
+"@1stg/tsconfig@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@1stg/tsconfig/-/tsconfig-2.3.0.tgz#28c7de2ba0dd774c4faadb8ea22982b67a3b9af2"
+  integrity sha512-J0l9wO/ILjqQDgEJZiYQej8Zc2LbSwkUAcYI1hxADP94OHYOfMNWeoKSl2plLxHz5JHhjRYXuVpZeEACeMI4JA==
 
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
@@ -241,7 +241,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.8.tgz#2483f565faca607b8535590e84e7de323f27764d"
   integrity sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==
 
-"@babel/core@^7.18.9":
+"@babel/core@^7.18.10":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.10.tgz#39ad504991d77f1f3da91be0b8b949a5bc466fb8"
   integrity sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==
@@ -271,7 +271,7 @@
     eslint-visitor-keys "^2.1.0"
     semver "^6.3.0"
 
-"@babel/eslint-plugin@^7.17.7":
+"@babel/eslint-plugin@^7.18.10":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/eslint-plugin/-/eslint-plugin-7.18.10.tgz#11f454b5d1aa64c42fcfd64abe93071c15ebea3c"
   integrity sha512-iV1OZj/7eg4wZIcsVEkXS3MUWdhmpLsu2h+9Zr2ppywKWdCRs6VfjxbRzmHHYeurTizrrnaJ9ZkbO8KOv4lauQ==
@@ -1380,10 +1380,10 @@
     resolve-from "^5.0.0"
     semver "^5.4.1"
 
-"@changesets/assemble-release-plan@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.0.tgz#35158dc9b496a4c108936ae8ad776ef855795ff6"
-  integrity sha512-ewY24PEbSec2eKX0+KM7eyENA2hUUp6s4LF9p/iBxTtc+TX2Xbx5rZnlLKZkc8tpuQ3PZbyjLFXWhd1PP6SjCg==
+"@changesets/assemble-release-plan@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.1.tgz#b66df8d4a5615d4d904b75f7b60faeb64eb1d506"
+  integrity sha512-d6ckasOWlKF9Mzs82jhl6TKSCgVvfLoUK1ERySrTg2TQJdrVUteZue6uEIYUTA7SgMu67UOSwol6R9yj1nTdjw==
   dependencies:
     "@babel/runtime" "^7.10.4"
     "@changesets/errors" "^0.1.4"
@@ -1408,19 +1408,19 @@
     "@changesets/types" "^5.1.0"
     dotenv "^8.1.0"
 
-"@changesets/cli@^2.24.2":
-  version "2.24.2"
-  resolved "https://registry.yarnpkg.com/@changesets/cli/-/cli-2.24.2.tgz#333ad412c821b582680fbc7f0d0596ebba442c2d"
-  integrity sha512-Bya7bnxF8Sz+O25M6kseAludVsCy5nXSW9u2Lbje/XbJTyU5q/xwIiXF9aTUzVi/4jyKoKoOasx7B1/z+NJLzg==
+"@changesets/cli@^2.24.3":
+  version "2.24.3"
+  resolved "https://registry.yarnpkg.com/@changesets/cli/-/cli-2.24.3.tgz#e6d8ab5d831d2249ca482955232a9a1c9ff02c21"
+  integrity sha512-okhRV+0WCQJa2Kmil/WvN5TK1o3+1JYSjrsGHqhjv+PYcDgDDgQ6I9J9OMBO9lfmNIpN7xSO80/BzxgvReO4Wg==
   dependencies:
     "@babel/runtime" "^7.10.4"
     "@changesets/apply-release-plan" "^6.0.4"
-    "@changesets/assemble-release-plan" "^5.2.0"
+    "@changesets/assemble-release-plan" "^5.2.1"
     "@changesets/changelog-git" "^0.1.12"
     "@changesets/config" "^2.1.1"
     "@changesets/errors" "^0.1.4"
     "@changesets/get-dependents-graph" "^1.3.3"
-    "@changesets/get-release-plan" "^3.0.13"
+    "@changesets/get-release-plan" "^3.0.14"
     "@changesets/git" "^1.4.1"
     "@changesets/logger" "^0.0.5"
     "@changesets/pre" "^1.0.12"
@@ -1486,13 +1486,13 @@
     dataloader "^1.4.0"
     node-fetch "^2.5.0"
 
-"@changesets/get-release-plan@^3.0.13":
-  version "3.0.13"
-  resolved "https://registry.yarnpkg.com/@changesets/get-release-plan/-/get-release-plan-3.0.13.tgz#f5f7b67b798d1bf2d6e8e546a60c199dd09bfeaf"
-  integrity sha512-Zl/UN4FUzb5LwmzhO2STRijJT5nQCN4syPEs0p1HSIR+O2iVOzes+2yTLF2zGiOx8qPOsFx/GRSAvuhSzm+9ig==
+"@changesets/get-release-plan@^3.0.14":
+  version "3.0.14"
+  resolved "https://registry.yarnpkg.com/@changesets/get-release-plan/-/get-release-plan-3.0.14.tgz#b4423028a90c63feec12e22c48078f106f8d01f4"
+  integrity sha512-xzSfeyIOvUnbqMuQXVKTYUizreWQfICwoQpvEHoePVbERLocc1tPo5lzR7dmVCFcaA/DcnbP6mxyioeq+JuzSg==
   dependencies:
     "@babel/runtime" "^7.10.4"
-    "@changesets/assemble-release-plan" "^5.2.0"
+    "@changesets/assemble-release-plan" "^5.2.1"
     "@changesets/config" "^2.1.1"
     "@changesets/pre" "^1.0.12"
     "@changesets/read" "^0.5.7"
@@ -1966,9 +1966,9 @@
     tslib "^2.3.1"
 
 "@markuplint/svelte-parser@^2.2.3":
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/@markuplint/svelte-parser/-/svelte-parser-2.2.3.tgz#0b133b423c9157b08b7d647cf5490397343c19a9"
-  integrity sha512-TQzuSFL2GrH1l8su+I+IdXXN7R3AgD1yUIjOSxUXo5IZXgqBYjNQGQmCkG0U84KGAJEdBDuzHsORHl3V9OUPPA==
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/@markuplint/svelte-parser/-/svelte-parser-2.2.4.tgz#33bd184cb6d6fdcc9a540131986a0b93889651d0"
+  integrity sha512-CtmKJzZdSmseGpM0qRrAI8jZ47Ub8hQn/0UfDEMs0JpREI8b+rxkWuIEiBpif5gP52bi7J/0kvLXz9P9Cg6rRg==
   dependencies:
     "@markuplint/html-parser" "2.2.2"
     "@markuplint/ml-ast" "2.0.1-dev.20220307.0"
@@ -2027,14 +2027,14 @@
     fastq "^1.6.0"
 
 "@npmcli/config@^4.0.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@npmcli/config/-/config-4.2.0.tgz#62b5d2b9cbf93fb2bc9f7cc947f25d7659ef849f"
-  integrity sha512-imWNz5dNWb2u+y41jyxL2WB389tkhu3a01Rchn16O/ur6GrnKySgOqdNG3N/9Z+mqxdISMEGKXI/POCauzz0dA==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@npmcli/config/-/config-4.2.1.tgz#7a4b46f4a315fe369a3f8543c67fae0b89549a40"
+  integrity sha512-iJEnXNAGGr7sGUcoKmeJNrc943vFiWrDWq6DNK/t+SuqoObmozMb3tN3G5T9yo3uBf5Cw4h+SWgoqSaiwczl0Q==
   dependencies:
     "@npmcli/map-workspaces" "^2.0.2"
     ini "^3.0.0"
     mkdirp-infer-owner "^2.0.0"
-    nopt "^5.0.0"
+    nopt "^6.0.0"
     proc-log "^2.0.0"
     read-package-json-fast "^2.0.3"
     semver "^7.3.5"
@@ -2067,14 +2067,14 @@
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
 
-"@prettier/plugin-pug@^2.1.1":
+"@prettier/plugin-pug@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@prettier/plugin-pug/-/plugin-pug-2.2.0.tgz#1794b1f27b34f9ef6e9519b8a64f2e5e73ad96eb"
   integrity sha512-W5CIXtMauz6xB4b0TeBW1Jxtk2ArggKMwqDHdGOfQ9ahABsttg2YZoQgLytETuo8Gjq0QkaGhAGD1pfDaUOZUQ==
   dependencies:
     pug-lexer "^5.0.0"
 
-"@prettier/plugin-ruby@^3.1.2":
+"@prettier/plugin-ruby@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@prettier/plugin-ruby/-/plugin-ruby-3.2.0.tgz#7301d2bcbb062638c839351fd5311e2bbd8fd740"
   integrity sha512-hCE4OVohe79FBAy0s9QLq8PmUc9cD4NbQtm2NHPWbSMq3mwHCRaxA+KYDRhHvG4AQIcf4YeQM8oRuTNyvLA41w==
@@ -2199,9 +2199,9 @@
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node@*", "@types/node@>=12", "@types/node@^18.0.0":
-  version "18.6.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.4.tgz#fd26723a8a3f8f46729812a7f9b4fc2d1608ed39"
-  integrity sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==
+  version "18.7.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.6.tgz#31743bc5772b6ac223845e18c3fc26f042713c83"
+  integrity sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==
 
 "@types/node@^12.7.1":
   version "12.20.55"
@@ -2233,14 +2233,14 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
-"@typescript-eslint/eslint-plugin@^5.30.7":
-  version "5.32.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz#e27e38cffa4a61226327c874a7be965e9a861624"
-  integrity sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==
+"@typescript-eslint/eslint-plugin@^5.33.0":
+  version "5.33.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.33.1.tgz#c0a480d05211660221eda963cc844732fe9b1714"
+  integrity sha512-S1iZIxrTvKkU3+m63YUOxYPKaP+yWDQrdhxTglVDVEVBf+aCSw85+BmJnyUaQQsk5TXFG/LpBu9fa+LrAQ91fQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.32.0"
-    "@typescript-eslint/type-utils" "5.32.0"
-    "@typescript-eslint/utils" "5.32.0"
+    "@typescript-eslint/scope-manager" "5.33.1"
+    "@typescript-eslint/type-utils" "5.33.1"
+    "@typescript-eslint/utils" "5.33.1"
     debug "^4.3.4"
     functional-red-black-tree "^1.0.1"
     ignore "^5.2.0"
@@ -2248,14 +2248,14 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.30.7":
-  version "5.32.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.32.0.tgz#1de243443bc6186fb153b9e395b842e46877ca5d"
-  integrity sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==
+"@typescript-eslint/parser@^5.33.0":
+  version "5.33.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.33.1.tgz#e4b253105b4d2a4362cfaa4e184e2d226c440ff3"
+  integrity sha512-IgLLtW7FOzoDlmaMoXdxG8HOCByTBXrB1V2ZQYSEV1ggMmJfAkMWTwUjjzagS6OkfpySyhKFkBw7A9jYmcHpZA==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.32.0"
-    "@typescript-eslint/types" "5.32.0"
-    "@typescript-eslint/typescript-estree" "5.32.0"
+    "@typescript-eslint/scope-manager" "5.33.1"
+    "@typescript-eslint/types" "5.33.1"
+    "@typescript-eslint/typescript-estree" "5.33.1"
     debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@5.29.0":
@@ -2266,20 +2266,20 @@
     "@typescript-eslint/types" "5.29.0"
     "@typescript-eslint/visitor-keys" "5.29.0"
 
-"@typescript-eslint/scope-manager@5.32.0":
-  version "5.32.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz#763386e963a8def470580cc36cf9228864190b95"
-  integrity sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==
+"@typescript-eslint/scope-manager@5.33.1":
+  version "5.33.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.33.1.tgz#8d31553e1b874210018ca069b3d192c6d23bc493"
+  integrity sha512-8ibcZSqy4c5m69QpzJn8XQq9NnqAToC8OdH/W6IXPXv83vRyEDPYLdjAlUx8h/rbusq6MkW4YdQzURGOqsn3CA==
   dependencies:
-    "@typescript-eslint/types" "5.32.0"
-    "@typescript-eslint/visitor-keys" "5.32.0"
+    "@typescript-eslint/types" "5.33.1"
+    "@typescript-eslint/visitor-keys" "5.33.1"
 
-"@typescript-eslint/type-utils@5.32.0":
-  version "5.32.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz#45a14506fe3fb908600b4cef2f70778f7b5cdc79"
-  integrity sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==
+"@typescript-eslint/type-utils@5.33.1":
+  version "5.33.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.33.1.tgz#1a14e94650a0ae39f6e3b77478baff002cec4367"
+  integrity sha512-X3pGsJsD8OiqhNa5fim41YtlnyiWMF/eKsEZGsHID2HcDqeSC5yr/uLOeph8rNF2/utwuI0IQoAK3fpoxcLl2g==
   dependencies:
-    "@typescript-eslint/utils" "5.32.0"
+    "@typescript-eslint/utils" "5.33.1"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
@@ -2288,10 +2288,10 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.29.0.tgz#7861d3d288c031703b2d97bc113696b4d8c19aab"
   integrity sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==
 
-"@typescript-eslint/types@5.32.0":
-  version "5.32.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.32.0.tgz#484273021eeeae87ddb288f39586ef5efeb6dcd8"
-  integrity sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==
+"@typescript-eslint/types@5.33.1":
+  version "5.33.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.33.1.tgz#3faef41793d527a519e19ab2747c12d6f3741ff7"
+  integrity sha512-7K6MoQPQh6WVEkMrMW5QOA5FO+BOwzHSNd0j3+BlBwd6vtzfZceJ8xJ7Um2XDi/O3umS8/qDX6jdy2i7CijkwQ==
 
 "@typescript-eslint/typescript-estree@5.29.0":
   version "5.29.0"
@@ -2306,13 +2306,13 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@5.32.0":
-  version "5.32.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz#282943f34babf07a4afa7b0ff347a8e7b6030d12"
-  integrity sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==
+"@typescript-eslint/typescript-estree@5.33.1":
+  version "5.33.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.1.tgz#a573bd360790afdcba80844e962d8b2031984f34"
+  integrity sha512-JOAzJ4pJ+tHzA2pgsWQi4804XisPHOtbvwUyqsuuq8+y5B5GMZs7lI1xDWs6V2d7gE/Ez5bTGojSK12+IIPtXA==
   dependencies:
-    "@typescript-eslint/types" "5.32.0"
-    "@typescript-eslint/visitor-keys" "5.32.0"
+    "@typescript-eslint/types" "5.33.1"
+    "@typescript-eslint/visitor-keys" "5.33.1"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -2331,15 +2331,15 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/utils@5.32.0", "@typescript-eslint/utils@^5.10.0":
-  version "5.32.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.32.0.tgz#eccb6b672b94516f1afc6508d05173c45924840c"
-  integrity sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==
+"@typescript-eslint/utils@5.33.1", "@typescript-eslint/utils@^5.10.0":
+  version "5.33.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.33.1.tgz#171725f924fe1fe82bb776522bb85bc034e88575"
+  integrity sha512-uphZjkMaZ4fE8CR4dU7BquOV6u0doeQAr8n6cQenl/poMaIyJtBu8eys5uk6u5HiDH01Mj5lzbJ5SfeDz7oqMQ==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.32.0"
-    "@typescript-eslint/types" "5.32.0"
-    "@typescript-eslint/typescript-estree" "5.32.0"
+    "@typescript-eslint/scope-manager" "5.33.1"
+    "@typescript-eslint/types" "5.33.1"
+    "@typescript-eslint/typescript-estree" "5.33.1"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
@@ -2351,12 +2351,12 @@
     "@typescript-eslint/types" "5.29.0"
     eslint-visitor-keys "^3.3.0"
 
-"@typescript-eslint/visitor-keys@5.32.0":
-  version "5.32.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz#b9715d0b11fdb5dd10fd0c42ff13987470525394"
-  integrity sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==
+"@typescript-eslint/visitor-keys@5.33.1":
+  version "5.33.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.1.tgz#0155c7571c8cd08956580b880aea327d5c34a18b"
+  integrity sha512-nwIxOK8Z2MPWltLKMLOEZwmfBZReqUdbEoHQXeCpa+sRVARe5twpJGHCB4dk9903Yaf0nMAlGbQfaAH92F60eg==
   dependencies:
-    "@typescript-eslint/types" "5.32.0"
+    "@typescript-eslint/types" "5.33.1"
     eslint-visitor-keys "^3.3.0"
 
 "@vue/babel-helper-vue-jsx-merge-props@^1.2.1":
@@ -2479,7 +2479,7 @@ JSONStream@^1.0.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-abbrev@1:
+abbrev@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
@@ -2866,7 +2866,7 @@ builtin-modules@^3.2.0, builtin-modules@^3.3.0:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
   integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
 
-builtins@^5.0.0, builtins@^5.0.1:
+builtins@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-5.0.1.tgz#87f6db9ab0458be728564fa81d876d8d74552fa9"
   integrity sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==
@@ -2911,9 +2911,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001370:
-  version "1.0.30001374"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz#3dab138e3f5485ba2e74bd13eca7fe1037ce6f57"
-  integrity sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==
+  version "1.0.30001378"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001378.tgz#3d2159bf5a8f9ca093275b0d3ecc717b00f27b67"
+  integrity sha512-JVQnfoO7FK7WvU4ZkBRbPjaot4+YqxogSDosHv0Hv5mWpUESmN+UubMU6L/hGz8QlQ2aY5U0vR6MOs6j/CXpNA==
 
 ccount@^2.0.0:
   version "2.0.1"
@@ -3127,16 +3127,16 @@ color-name@~1.1.4:
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 colord@^2.9.1:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.2.tgz#25e2bacbbaa65991422c07ea209e2089428effb1"
-  integrity sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.3.tgz#4f8ce919de456f1d5c1c368c307fe20f3e59fb43"
+  integrity sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==
 
 colorette@^2.0.16, colorette@^2.0.17:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
-commander@^9.2.0, commander@^9.3.0:
+commander@^9.3.0, commander@^9.4.0:
   version "9.4.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
   integrity sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==
@@ -3493,9 +3493,9 @@ eastasianwidth@^0.2.0:
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 electron-to-chromium@^1.4.202:
-  version "1.4.211"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz#afaa8b58313807501312d598d99b953568d60f91"
-  integrity sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A==
+  version "1.4.224"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.224.tgz#ecf2eed395cfedcbbe634658ccc4b457f7b254c3"
+  integrity sha512-dOujC5Yzj0nOVE23iD5HKqrRSDj2SD7RazpZS/b/WX85MtO6/LzKDF4TlYZTBteB+7fvSg5JpWh0sN7fImNF8w==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -3681,10 +3681,10 @@ eslint-import-resolver-node@^0.3.6:
     debug "^3.2.7"
     resolve "^1.20.0"
 
-eslint-import-resolver-typescript@^3.3.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.4.0.tgz#a7e334b86d638f49956f2b0dfbde29daa9c32dcd"
-  integrity sha512-rBCgiEovwX/HQ8ESWV+XIWZaFiRtDeAXNZdcTATB8UbMuadc9qfGOlIP+vy+c7nsgfEBN4NTwy5qunGNptDP0Q==
+eslint-import-resolver-typescript@^3.4.1:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.4.2.tgz#9ee568aad73e63eee37b7b5344da5467806b90a3"
+  integrity sha512-8SuWlRIEO83X9PsJSK9VjgH0EDk1ZzNI36+r3C0xNYVJ+O1+TprOFtTwqqyPMHG+br/I9A5Q80RE7K3/eIr9XA==
   dependencies:
     debug "^4.3.4"
     enhanced-resolve "^5.10.0"
@@ -3692,7 +3692,7 @@ eslint-import-resolver-typescript@^3.3.0:
     globby "^13.1.2"
     is-core-module "^2.9.0"
     is-glob "^4.0.3"
-    synckit "^0.8.1"
+    synckit "^0.8.3"
 
 eslint-mdx@^2.0.2:
   version "2.0.2"
@@ -3715,12 +3715,11 @@ eslint-mdx@^2.0.2:
     vfile "^5.3.4"
 
 eslint-module-utils@^2.7.3:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz#ad7e3a10552fdd0642e1e55292781bd6e34876ee"
-  integrity sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz#4f3e41116aaf13a20792261e61d3a2e7e0583974"
+  integrity sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==
   dependencies:
     debug "^3.2.7"
-    find-up "^2.1.0"
 
 eslint-plugin-css@^0.6.0:
   version "0.6.0"
@@ -3777,17 +3776,17 @@ eslint-plugin-eslint-comments@^3.2.0:
     object.values "^1.1.5"
     resolve "^1.22.1"
 
-eslint-plugin-jest@^26.6.0:
-  version "26.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.7.0.tgz#41d405ac9143e1284a3401282db47ed459436778"
-  integrity sha512-/YNitdfG3o3cC6juZziAdkk6nfJt01jXVfj4AgaYVLs7bupHzRDL5K+eipdzhDXtQsiqaX1TzfwSuRlEgeln1A==
+eslint-plugin-jest@^26.8.2:
+  version "26.8.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.8.3.tgz#f5d9bb162636491c8f6f0cd2743fe67c86569338"
+  integrity sha512-2roWu1MkEiihQ/qEszPPoaoqVI1x2D8Jtadk5AmoXTdEeNVPMu01Dtz7jIuTOAmdW3L+tSkPZOtEtQroYJDt0A==
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 
-eslint-plugin-jsdoc@^39.3.3:
-  version "39.3.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.4.tgz#6d18c5a071ada5babce9636b02a6c8355e9de2e8"
-  integrity sha512-dYWXhMMHJaq++bY2hyByhgiRzt5qQ7XdfQGiHrU9f3APSSVZ/HuOnXuvUUX7W0jO55Udsu4/7iRlpF/yLFQdSA==
+eslint-plugin-jsdoc@^39.3.6:
+  version "39.3.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.6.tgz#6ba29f32368d72a51335a3dc9ccd22ad0437665d"
+  integrity sha512-R6dZ4t83qPdMhIOGr7g2QII2pwCjYyKP+z0tPOfO1bbAbQyKC20Y2Rd6z1te86Lq3T7uM8bNo+VD9YFpE8HU/g==
   dependencies:
     "@es-joy/jsdoccomment" "~0.31.0"
     comment-parser "1.3.1"
@@ -3797,10 +3796,10 @@ eslint-plugin-jsdoc@^39.3.3:
     semver "^7.3.7"
     spdx-expression-parse "^3.0.1"
 
-eslint-plugin-json-schema-validator@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-json-schema-validator/-/eslint-plugin-json-schema-validator-4.0.0.tgz#bd2f3283df3bb8f1361dabe71fa97b165ac7c548"
-  integrity sha512-j1BuYdrcMRN2EFkUJAB+M0xYUdXZSo07GNzf9H3q1hRA+mQ2AxgkPR7jV4r6VRuu8PSjSyb3mTZ2uhzcHLEftw==
+eslint-plugin-json-schema-validator@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-json-schema-validator/-/eslint-plugin-json-schema-validator-4.0.1.tgz#00bff11fd16ef9a0bff7bb1cf0092b1691ce9f43"
+  integrity sha512-TW3e9Itet+PlvkUvVVy2ZvE72XN18vS99KerwEvHqLwxWVBPATAGlkX1q9XwY76dhQLApXg2NSRwbN8hbbLqZQ==
   dependencies:
     ajv "^8.0.0"
     debug "^4.3.1"
@@ -3814,9 +3813,9 @@ eslint-plugin-json-schema-validator@^4.0.0:
     yaml-eslint-parser "^1.0.0"
 
 eslint-plugin-jsonc@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.3.1.tgz#2048b559dc4239bf3c9c0f52d945c7e12e210c19"
-  integrity sha512-8sgWGWiVRMFL6xGawRymrE4RjZJgiU0rXYgFFb71wvdwuUkPgWSvfFtc8jfwcgjjqFjis8vzCUFsg7SciMEDWw==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.4.0.tgz#83a0f9a22689492d58514ab0464fa0612dceabc7"
+  integrity sha512-YXy5PjyUL9gFYal6pYijd8P6EmpeWskv7PVhB9Py/AwKPn+hwnQHcIzQILiLfxztfhtWiRIUSzoLe/JThZgSUw==
   dependencies:
     eslint-utils "^3.0.0"
     jsonc-eslint-parser "^2.0.4"
@@ -3905,7 +3904,7 @@ eslint-plugin-react@^7.30.1:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.7"
 
-eslint-plugin-regexp@^1.7.0:
+eslint-plugin-regexp@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-regexp/-/eslint-plugin-regexp-1.8.0.tgz#8a3c08ec0a3ad0b2776bf74cde22009dde30dab8"
   integrity sha512-zRtG5OpWF+istPsjdZYGH23s2ONuN+EDzioGH81WUPehvwlW/l2sh2EBYdnf58UL9nF4oPQXktaABSOpfeQJ9g==
@@ -3924,15 +3923,18 @@ eslint-plugin-simple-import-sort@^7.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz#a1dad262f46d2184a90095a60c66fef74727f0f8"
   integrity sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==
 
-eslint-plugin-sonar@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sonar/-/eslint-plugin-sonar-0.8.0.tgz#c67b3da53ca3a8531e3e333891b54c1d92f1176b"
-  integrity sha512-5ZqgYIY1NSyR80v9RXbgwaK/jkHuGmuBa7ybsDEhwPydGplYvoj4zx8ahR8II7SoIOXPuzeh8HifEvKQSxu0iQ==
+eslint-plugin-sonar@^0.9.0:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sonar/-/eslint-plugin-sonar-0.9.1.tgz#7c31b79202eb45dd4142998289cf297b08736b77"
+  integrity sha512-+N56TU0PkUKitb4OC1tSamibSF9EAM1DWZOPwrFDwpO7OTpWwuH6lUkrB1I+Q2NJoK4Fmy6m1QqvfvLRgkit4g==
   dependencies:
     "@babel/eslint-parser" "^7.17.0"
     builtin-modules "^3.2.0"
     bytes "^3.1.2"
+    eslint-plugin-react "^7.30.1"
+    eslint-plugin-react-hooks "^4.6.0"
     eslint-plugin-sonarjs "^0.13.0"
+    regexpp "^3.2.0"
     scslre "^0.1.6"
 
 eslint-plugin-sonarjs@^0.13.0:
@@ -3940,15 +3942,15 @@ eslint-plugin-sonarjs@^0.13.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.13.0.tgz#c34d140cc90abaaed38f5a5201a2ccdebe398862"
   integrity sha512-t3m7ta0EspzDxSOZh3cEOJIJVZgN/TlJYaBGnQlK6W/PZNbWep8q4RQskkJkA7/zwNpX0BaoEOSUUrqaADVoqA==
 
-eslint-plugin-sonarjs@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.14.0.tgz#112d159ba7516a2a69bb1a6d6cab782e23bca259"
-  integrity sha512-0X0q3fB8ghppms19cR2oIK2ajoFp7DEy3AVGDqO7WX02r1aWOzkrHa+veatGZw+R7amgBvfcF0qHCG66p9Zoag==
+eslint-plugin-sonarjs@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.15.0.tgz#f9c904f143f4e2336f2923be08399b32b5bd2781"
+  integrity sha512-LuxHdAe6VqSbi1phsUvNjbmXLuvlobmryQJJNyQYbdubCfz6K8tmgoqNiJPnz0pP2AbYDbtuPm0ajOMgMrC+dQ==
 
-eslint-plugin-svelte@^2.2.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-svelte/-/eslint-plugin-svelte-2.4.1.tgz#db1b2749243b60ed7b6d11ab2a448e48d1232a83"
-  integrity sha512-fjS6JgZDap2wFp2ofqwL8+z1CGYTxP2y6M6rSYZr1aYhRmZA3pW+3FYjJeyVSBz9dIEZPomJGMAIBEJHBiEgwQ==
+eslint-plugin-svelte@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-svelte/-/eslint-plugin-svelte-2.6.0.tgz#55765429ddd58ffae4e7fc415edf687897c6e50d"
+  integrity sha512-RS8y4mbJi3/O0XMimjSqT/X6esgUXbT4Skh1Ty4UtM89vamFms10dFfBBbmNBcJim+vesBgaHOf3pmihkts8EQ==
   dependencies:
     debug "^4.3.1"
     eslint-utils "^3.0.0"
@@ -3957,7 +3959,7 @@ eslint-plugin-svelte@^2.2.0:
     postcss-load-config "^3.1.4"
     postcss-safe-parser "^6.0.0"
     sourcemap-codec "^1.4.8"
-    svelte-eslint-parser "^0.17.0"
+    svelte-eslint-parser "^0.18.0"
 
 eslint-plugin-toml@^0.3.1:
   version "0.3.1"
@@ -3993,7 +3995,7 @@ eslint-plugin-utils@^0.3.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-utils/-/eslint-plugin-utils-0.3.1.tgz#3d75085cbc6a3d8ce05776f4bb265f864e36d0af"
   integrity sha512-bomAAoDLoAZ54eu2+fTOMl02q+fhGlQkU9LqIbsADFiTaaWWpfozbeX70I9RxwwkzZdFpfG+n06yeKlWv7s8dQ==
 
-eslint-plugin-vue@^9.2.0:
+eslint-plugin-vue@^9.3.0:
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-9.3.0.tgz#c3f5ce515dae387e062428725c5cf96098d9da0b"
   integrity sha512-iscKKkBZgm6fGZwFt6poRoWC0Wy2dQOlwUPW++CiPoQiw1enctV2Hj5DBzzjJZfyqs+FAXhgzL4q0Ww03AgSmQ==
@@ -4006,7 +4008,7 @@ eslint-plugin-vue@^9.2.0:
     vue-eslint-parser "^9.0.1"
     xml-name-validator "^4.0.0"
 
-eslint-plugin-yml@^1.0.0:
+eslint-plugin-yml@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-yml/-/eslint-plugin-yml-1.1.0.tgz#cf280b79acc704b9bc1d39aef28e8dbcc65a18a2"
   integrity sha512-64g3vWwolk9d+FykuqxXGLn3oGEK2ZecIAyfIEsyuSHBQkR8utp5h8e75R6tGph1IRggoGl27QQ2oi2M1IF1Vw==
@@ -4066,10 +4068,10 @@ eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.1.0, eslint-visitor-keys@^3.3
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
-eslint@^8.20.0:
-  version "8.21.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.21.0.tgz#1940a68d7e0573cef6f50037addee295ff9be9ef"
-  integrity sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==
+eslint@^8.22.0:
+  version "8.22.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.22.0.tgz#78fcb044196dfa7eef30a9d65944f6f980402c48"
+  integrity sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==
   dependencies:
     "@eslint/eslintrc" "^1.3.0"
     "@humanwhocodes/config-array" "^0.10.4"
@@ -4332,13 +4334,6 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
-
-find-up@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
-  integrity sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==
-  dependencies:
-    locate-path "^2.0.0"
 
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
@@ -4674,7 +4669,7 @@ has-property-descriptors@^1.0.0:
   dependencies:
     get-intrinsic "^1.1.1"
 
-has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3:
+has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
@@ -4718,9 +4713,9 @@ hosted-git-info@^4.0.1:
     lru-cache "^6.0.0"
 
 hosted-git-info@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-5.0.0.tgz#df7a06678b4ebd722139786303db80fdf302ea56"
-  integrity sha512-rRnjWu0Bxj+nIfUOkz0695C0H6tRrN5iYIzYejb0tDEefe2AekHu/U5Kn9pEie5vsJqpNQU02az7TGSH3qpz4Q==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-5.1.0.tgz#9786123f92ef3627f24abc3f15c20d98ec4a6594"
+  integrity sha512-Ek+QmMEqZF8XrbFdwoDjSbm7rT23pCgEMOJmz6GPk/s4yH//RQfNPArhIxbguNxROq/+5lNBwCDHMhA903Kx1Q==
   dependencies:
     lru-cache "^7.5.1"
 
@@ -4785,11 +4780,9 @@ import-from@4.0.0:
   integrity sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==
 
 import-meta-resolve@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-2.0.3.tgz#117f3dc9a6415e82c32530545e1cf91be5c0a5d1"
-  integrity sha512-fpAppnBpZ3ymQ/dPP97TNsco1HB5+V9SYJ3chY50PP8xn4U/w+Y6ovWBmTImB/prmGsTjzPh8pQYY+EVBlr9mw==
-  dependencies:
-    builtins "^5.0.0"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-2.1.0.tgz#c8952d331ed6e9bb6ad524a7549deb3d34af41ce"
+  integrity sha512-yG9pxkWJVTy4cmRsNWE3ztFdtFuYIV8G4N+cbCkO8b+qngkLyIUhxQFuZ0qJm67+0nUOxjMPT7nfksPKza1v2g==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -5241,12 +5234,12 @@ jsonparse@^1.2.0:
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz#afe5efe4332cd3515c065072bd4d6b0aa22152bd"
-  integrity sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz#76b3e6e6cece5c69d49a5792c3d01bd1a0cdc7ea"
+  integrity sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==
   dependencies:
     array-includes "^3.1.5"
-    object.assign "^4.1.2"
+    object.assign "^4.1.3"
 
 kind-of@^6.0.3:
   version "6.0.3"
@@ -5315,11 +5308,6 @@ lines-and-columns@^2.0.2:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-2.0.3.tgz#b2f0badedb556b747020ab8ea7f0373e22efac1b"
   integrity sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==
 
-linguist-languages@^7.9.0:
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/linguist-languages/-/linguist-languages-7.21.0.tgz#da0184f622367cb092f1f8ba435937a85534f675"
-  integrity sha512-KrWJJbFOvlDhjlt5OhUipVlXg+plUfRurICAyij1ZVxQcqPt/zeReb9KiUVdGUwwhS/2KS9h3TbyfYLA5MDlxQ==
-
 lint-staged@^13.0.3:
   version "13.0.3"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.0.3.tgz#d7cdf03a3830b327a2b63c6aec953d71d9dc48c6"
@@ -5380,14 +5368,6 @@ load-yaml-file@^0.2.0:
     js-yaml "^3.13.0"
     pify "^4.0.1"
     strip-bom "^3.0.0"
-
-locate-path@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
-  integrity sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==
-  dependencies:
-    p-locate "^2.0.0"
-    path-exists "^3.0.0"
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -5466,9 +5446,9 @@ lru-cache@^6.0.0:
     yallist "^4.0.0"
 
 lru-cache@^7.5.1:
-  version "7.13.2"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.13.2.tgz#bb5d3f1deea3f3a7a35c1c44345566a612e09cd0"
-  integrity sha512-VJL3nIpA79TodY/ctmZEfhASgqekbT574/c4j3jn4bKXbSCnTTCH/KltZyvL2GlV+tGSMtsWyem8DCX7qKTMBA==
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.0.tgz#21be64954a4680e303a09e9468f880b98a0b3c7f"
+  integrity sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==
 
 lru-queue@^0.1.0:
   version "0.1.0"
@@ -5516,9 +5496,9 @@ markuplint-angular-parser@^1.1.3:
     tslib "^2.4.0"
 
 markuplint@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/markuplint/-/markuplint-2.10.0.tgz#6d15c0b6b105a9e5f55f0b5965afcc523b10a7a0"
-  integrity sha512-baVjRvVOgV+MPR5180xEahI32yH7CbQmVH4sbnb/nc4gvSoJ9jjFg03dkZsopVOSp/XkuvH9L4JhjDwtUJmRnQ==
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/markuplint/-/markuplint-2.10.1.tgz#e095c85c349a4274b2cc1f9eedeae283846e6229"
+  integrity sha512-SkVQjPQxiHF/S4k3NqWZ9dA+q+lLGAKyTJfmqdVPUZhC74/rvt6bZ9ZW/WXxCOZbccQfWKq1nSTDU0GXJbGkdQ==
   dependencies:
     "@markuplint/create-rule-helper" "2.3.3"
     "@markuplint/file-resolver" "2.5.3"
@@ -6357,12 +6337,12 @@ nodent-transform@^3.2.4:
   resolved "https://registry.yarnpkg.com/nodent-transform/-/nodent-transform-3.2.9.tgz#ec11a6116b5476e60bc212371cf6b8e4c74f40b6"
   integrity sha512-4a5FH4WLi+daH/CGD5o/JWRR8W5tlCkd3nrDSkxbOzscJTyTUITltvOJeQjg3HJ1YgEuNyiPhQbvbtRjkQBByQ==
 
-nopt@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
-  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
+nopt@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-6.0.0.tgz#245801d8ebf409c6df22ab9d95b65e1309cdb16d"
+  integrity sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==
   dependencies:
-    abbrev "1"
+    abbrev "^1.0.0"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -6445,14 +6425,14 @@ object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object.assign@^4.1.0, object.assign@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
-  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
+object.assign@^4.1.0, object.assign@^4.1.2, object.assign@^4.1.3:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
+  integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
   dependencies:
-    call-bind "^1.0.0"
-    define-properties "^1.1.3"
-    has-symbols "^1.0.1"
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
 object.entries@^1.1.5:
@@ -6586,13 +6566,6 @@ p-is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
   integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
-p-limit@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
-  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
-  dependencies:
-    p-try "^1.0.0"
-
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -6606,13 +6579,6 @@ p-limit@^3.0.2:
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
-
-p-locate@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
-  integrity sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==
-  dependencies:
-    p-limit "^1.1.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -6639,11 +6605,6 @@ p-map@^4.0.0:
   integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
-
-p-try@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-  integrity sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -6739,11 +6700,6 @@ patch-package@^6.4.7:
     semver "^5.6.0"
     slash "^2.0.0"
     tmp "^0.0.33"
-
-path-exists@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
-  integrity sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -6856,9 +6812,9 @@ postcss-value-parser@^4.1.0:
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss@^8.4.5:
-  version "8.4.14"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
-  integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
+  version "8.4.16"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.16.tgz#33a1d675fac39941f5f445db0de4db2b6e01d43c"
+  integrity sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==
   dependencies:
     nanoid "^3.3.4"
     picocolors "^1.0.0"
@@ -6886,27 +6842,26 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier-plugin-ini@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-ini/-/prettier-plugin-ini-1.0.0.tgz#af0ecea207683c1598190d69e9a8cb49e94690eb"
-  integrity sha512-/b/D6U2Ivo0CW8kvfXpzNTl/6ehnTngNeUiS1Ao69uxbugHL1BVaT1gUX7BgobrdQPvWRgH2j2hOyBw7bEPNEA==
+prettier-plugin-ini@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-ini/-/prettier-plugin-ini-1.1.0.tgz#922fc10398a72e1bfe2d742c702b58060da43eb5"
+  integrity sha512-xlWM//GrLYU5CX3Qdn5isOlxz1LHnTi4fdSHZX/UYV/C5ipbcFfdCglENoOPGp4N5EvtA5Q1FuVhg95K58TMRg==
   dependencies:
     prettier ">=2.3"
 
-prettier-plugin-pkg@^0.16.0:
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-pkg/-/prettier-plugin-pkg-0.16.1.tgz#7cf9c06a1d475f89a3695d3cf9f73c13ce06374e"
-  integrity sha512-wy6mekVVYluwNLCqTmayW2916ABTLjf7SFQWcOfJ+nnqg1AavJiCyfZrapvaGUbinivdnm3IhIjxMjTjkXgVgQ==
+prettier-plugin-pkg@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-pkg/-/prettier-plugin-pkg-0.17.0.tgz#5d77b7feec480d746b57359505b097d060d855c0"
+  integrity sha512-TwQqf8XT+esIy75Js4WywCjhhCya46uCX2kP3elgCmmHwP9twybGYJfZLYJ0wnKgkFUXjlAzDypbPcNXfJA/mg==
 
-prettier-plugin-properties@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-properties/-/prettier-plugin-properties-0.1.0.tgz#15302dfb9b34c0a845bd8ed6f8084e3765cdc05f"
-  integrity sha512-lObSgVaTVWSyYWxKMOzRGmvQp64S1qumu5vS91ZlMc198ay8EGUuDH+Tc019iMJXc2KNpdAYif2qAJA6mjTkgA==
+prettier-plugin-properties@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-properties/-/prettier-plugin-properties-0.2.0.tgz#ad025de49ea55ce2c20ee498d1ed713f6ee99311"
+  integrity sha512-Mt+z2nPkG+apJJLxfv8/Z/knhF/pTFUyxTeaRCuvQhs33rzQEkquGXSyKyvcWfijOTlOvB6KnmSJXpmblLNYrQ==
   dependencies:
     dot-properties "^1.0.0"
-    linguist-languages "^7.9.0"
 
-prettier-plugin-sh@^0.12.6:
+prettier-plugin-sh@^0.12.8:
   version "0.12.8"
   resolved "https://registry.yarnpkg.com/prettier-plugin-sh/-/prettier-plugin-sh-0.12.8.tgz#174106774c06304e082f030ecb05cdcaeabb2585"
   integrity sha512-VOq8h2Gn5UzrCIKm4p/nAScXJbN09HdyFDknAcxt6Qu/tv/juu9bahxSrcnM9XWYA+Spz1F1ANJ4LhfwB7+Q1Q==
@@ -6915,10 +6870,10 @@ prettier-plugin-sh@^0.12.6:
     sh-syntax "^0.3.6"
     synckit "^0.8.1"
 
-prettier-plugin-stylus@^0.0.1-beta.3:
-  version "0.0.1-beta.6"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-stylus/-/prettier-plugin-stylus-0.0.1-beta.6.tgz#cf7d40fb688bdac6b3be687ad6acf42e6f0b5ada"
-  integrity sha512-5rRUaz0H/iMFyqdiRyYx8E+l60dy6Dt43a29LiC2jAChlTPvKnKW5FU+r/OJBXWuCdNvQL2p3H1qHCXQQLaukw==
+prettier-plugin-stylus@^0.0.1-beta.8:
+  version "0.0.1-beta.8"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-stylus/-/prettier-plugin-stylus-0.0.1-beta.8.tgz#b9d0f0105cd2747e882b8225dfbd5e20b92978b1"
+  integrity sha512-EjM9yiMC2PNbfNpc/3WQVNnyTnQaMvlkNNv2odLWiyoqhmv1QzSvib3CEF9MeumENTNT1bNrqjPJUA2qYfskJg==
   dependencies:
     stylus "^0.57.0"
 
@@ -7857,9 +7812,9 @@ remark-lint@^9.0.0, remark-lint@^9.1.1:
     unified "^10.1.0"
 
 remark-mdx@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/remark-mdx/-/remark-mdx-2.1.2.tgz#eea2784fa5697e14f6e0686700077986b88b8078"
-  integrity sha512-npQagPdczPAv0xN9F8GSi5hJfAe/z6nBjylyfOfjLOmz086ahWrIjlk4BulRfNhA+asutqWxyuT3DFVsxiTVHA==
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/remark-mdx/-/remark-mdx-2.1.3.tgz#6273e8b94d27ade35407a63bc8cdd04592f7be9f"
+  integrity sha512-3SmtXOy9+jIaVctL8Cs3VAQInjRLGOwNXfrBB9KCT+EpJpKD3PQiy0x8hUNGyjQmdyOs40BqgPU7kYtH9uoR6w==
   dependencies:
     mdast-util-mdx "^2.0.0"
     micromark-extension-mdxjs "^1.0.0"
@@ -7980,10 +7935,10 @@ remark-preset-lint-recommended@^6.1.2:
     remark-lint-ordered-list-marker-style "^3.0.0"
     unified "^10.0.0"
 
-remark-preset-prettier@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/remark-preset-prettier/-/remark-preset-prettier-1.0.1.tgz#119648e41fd565945f1d3a7d1d75ce35d13fc791"
-  integrity sha512-fjODzwpJ9kdTYZrT7iW+1Me87EW9tq6AlP9LF5Ynbqi8vHvLGW5oAHFNm83WBmQ0nDVQsPVcAEkadzqHTrKXJA==
+remark-preset-prettier@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-preset-prettier/-/remark-preset-prettier-1.0.2.tgz#57146d9128447840690ae25c1797c34d1883a40f"
+  integrity sha512-GiTOnOh5NyG0XesZqNLzAqXqs3Z/HFmStcPZP/ZMIQvHOPGmv6zDixItNZeVtDDDWgn0J6BuALI/mv0m4pA6vQ==
   dependencies:
     remark-lint-blank-lines-1-0-2 "*"
     remark-lint-blockquote-indentation "*"
@@ -8211,7 +8166,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.3.7, semver@^7.0.0, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.6, semver@^7.3.7:
+semver@7.3.7, semver@^7.0.0, semver@^7.3.4, semver@^7.3.5, semver@^7.3.6, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
@@ -8597,10 +8552,10 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-svelte-eslint-parser@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/svelte-eslint-parser/-/svelte-eslint-parser-0.17.0.tgz#fe740f9b1fbaeae68fa5d52b30cd8777e7841aae"
-  integrity sha512-hHuB9upgGBNIMb7mL2UyGHxnNitQqWAB3GojHtN2w+kTH4jmZmNCHR4aHln8AjXQuQ2+rYTyVS0LeBPXL+ZrDQ==
+svelte-eslint-parser@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/svelte-eslint-parser/-/svelte-eslint-parser-0.18.0.tgz#efabf2461fdcc46bf952ddaf6ff5fa6232e02a36"
+  integrity sha512-XYmAW8I45Bd5RhUr4JpCbu0sSZ2jzvfG1NkOW8Hxv+eTxReXVBBCRg1d7czRY+iZOg289dTI5JHtu9ZR4R9dCA==
   dependencies:
     eslint-scope "^7.0.0"
     eslint-visitor-keys "^3.0.0"
@@ -8616,10 +8571,10 @@ svg-tags@^1.0.0:
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
   integrity sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==
 
-synckit@^0.8.0, synckit@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.1.tgz#697111240114a15a393fcb92786a4218bfead47f"
-  integrity sha512-rJEeygO5PNmcZICmrgnbOd2usi5zWE1ESc0Gn5tTmJlongoU8zCTwMFQtar2UgMSiR68vK9afPQ+uVs2lURSIA==
+synckit@^0.8.0, synckit@^0.8.1, synckit@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.3.tgz#f36ca23fb7cbcf2b2b78c9e553ce6764dc6aa415"
+  integrity sha512-1goXnDYNJlKwCM37f5MTzRwo+8SqutgVtg2d37D6YnHHT4E3IhQMRfKiGdfTZU7LBlI6T8inCQUxnMBFHrbqWw==
   dependencies:
     "@pkgr/utils" "^2.3.0"
     tslib "^2.4.0"
@@ -9420,15 +9375,15 @@ yargs@^17.0.0, yargs@^17.1.1:
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
 
-yarn-deduplicate@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/yarn-deduplicate/-/yarn-deduplicate-5.0.0.tgz#8977b9a4b1a2fd905568c3a23507b1021fa381eb"
-  integrity sha512-sYA5tqBSY3m+DtEcwfMYP1G2zWq1UtWSNg2goESqiu/JXBoBF/Qh+FuTJGGjsrisxL+5yOgq/ez1Rd+KSPwzvA==
+yarn-deduplicate@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/yarn-deduplicate/-/yarn-deduplicate-5.0.2.tgz#b56484c94d8f1163a828bf20516607f89c078675"
+  integrity sha512-pxKa+dM7DMQ4X2vYLKqGCUgtEoTtdMVk9gNoIsxsMSP0rOV51IWFcKHfRIcZjAPNgHTrxz46sKB4xr7Nte7jdw==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
-    commander "^9.2.0"
-    semver "^7.3.2"
-    tslib "^2.3.1"
+    commander "^9.4.0"
+    semver "^7.3.7"
+    tslib "^2.4.0"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Mentioning _VSCode_ in the display name and description is redundant, as it’s used for representing the extension inside VSCode (or even an alternative compatible editor that isn’t VSCode).

The `qna` link is linked from https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx&ssr=false#qna. By default it appears to link the repository issue tracker.

The sponsor url is rendered in VSCode. For example:

![remark extension page in VSCode](https://user-images.githubusercontent.com/779047/183250079-063d3475-0a5d-466c-a3da-e98ba8a3d8e4.png 'remark extension page in VSCode')

The `funding` field is for npm packages and is actually meaningless for VSCode extensions. I don’t know what the `donate` field is used for, but it seems redundant too.