### PR TITLE
fix: remove superfluous `embeddedLanguages` setting

### DIFF
--- a/.changeset/great-owls-sip.md
+++ b/.changeset/great-owls-sip.md
@@ -1,0 +1,5 @@
+---
+"vscode-mdx": patch
+---
+
+fix: remove superfluous `embeddedLanguages` setting

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
         "embeddedLanguages": {
           "source.js": "javascript",
           "source.js.jsx": "javascriptreact",
-          "text.html.markdown": "markdown",
           "meta.tag.js": "jsx-tags",
           "meta.tag.without-attributes.js": "jsx-tags",
           "meta.embedded.block.frontmatter": "yaml",


### PR DESCRIPTION
Addresses issue #203. I believe that `embeddedLanguages` should not contain `"text.html.markdown": "markdown"`; see my response to the issue at https://github.com/mdx-js/vscode-mdx/issues/203#issuecomment-1221812813 