### PR TITLE
feat: support for highlighting JSX evaluated expressions

### DIFF
--- a/.changeset/short-coins-bow.md
+++ b/.changeset/short-coins-bow.md
@@ -12,6 +12,3 @@ In JSX, you can include JS expressions within tags, like:
 ```
 
 This PR adds syntax highlighting for those expressions by adding a new pattern in the `tmLanguage.json`.
-
-### Limitations
-It will still highlight JS that isn’t valid to include in a JSX evaluated expression (eg. a class definition), which as far as I can tell is a limitation of how embedded languages work in TextMate syntax highlighting definitions.

--- a/.changeset/short-coins-bow.md
+++ b/.changeset/short-coins-bow.md
@@ -1,0 +1,17 @@
+---
+'vscode-mdx': minor
+---
+
+Support for highlighting JSX evaluated expressions
+
+In JSX, you can include JS expressions within tags, like:
+```
+<ATag>
+{doSomething(‘a’, 7)}
+</asdfadf
+```
+
+This PR adds syntax highlighting for those expressions by adding a new pattern in the `tmLanguage.json`.
+
+### Limitations
+It will still highlight JS that isn’t valid to include in a JSX evaluated expression (eg. a class definition), which as far as I can tell is a limitation of how embedded languages work in TextMate syntax highlighting definitions.

--- a/syntaxes/mdx.tmLanguage.json
+++ b/syntaxes/mdx.tmLanguage.json
@@ -69,7 +69,7 @@
           ]
         }
       }
-      },
+    },
     "markdown": {
       "contentName": "text.html.markdown",
       "patterns": [

--- a/syntaxes/mdx.tmLanguage.json
+++ b/syntaxes/mdx.tmLanguage.json
@@ -7,6 +7,9 @@
     },
     {
       "include": "#markdown"
+    },
+    { 
+      "include": "#jsx-evaluated-code"
     }
   ],
   "repository": {
@@ -17,6 +20,9 @@
         },
         {
           "include": "#jsx-tag"
+        },
+        {
+          "include": "#jsx-evaluated-code"
         }
       ],
       "repository": {
@@ -47,9 +53,23 @@
               ]
             }
           ]
+        },
+        "jsx-evaluated-code": {
+          "patterns": [
+            {
+              "begin": "(?!```$){",
+              "end": "}",
+              "contentName": "source.js.jsx",
+              "patterns": [
+                { 
+                  "include": "source.js.jsx"
+                }
+              ]
+            }
+          ]
         }
       }
-    },
+      },
     "markdown": {
       "contentName": "text.html.markdown",
       "patterns": [

--- a/test/fixture.mdx
+++ b/test/fixture.mdx
@@ -16,8 +16,13 @@ Lorem ipsum dolor sit amet, consectetur adipiscing **elit**. Ut ac lobortis <b>v
 }
 ```
 
-<Component>{/* This is a comment */}</Component>
+<Component>
+  {/* This is a comment */}
+  {console.log('calling a function')}
+</Component>
 
 ## Subtitle
 
 Lorem ipsum dolor sit _amet_, consectetur adipiscing elit. Ut ac lobortis velit.
+
+{3 * 7}


### PR DESCRIPTION
In JSX, you can include JS expressions within tags, like:
```
{doSomething(‘a’, 7)}
```

This PR adds syntax highlighting for those expressions.

### Limitations
It will still highlight JS that isn’t valid to include in a JSX evaluated expression (eg. a class definition), which as far as I can tell is a limitation of how embedded languages work in TextMate syntax highlighting definitions.
