### PR TITLE
chore: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 *.log
 *.tsbuildinfo
 .*cache
-!/.vscode
-/.vscode-test
-lib
-node_modules
+.vscode-test/
+node_modules/


### PR DESCRIPTION
The `lib` folder is removed, as it doesn’t exist in this repository. `node_modules` and `.vscode-test` have been marked explicitly as directories. The `.vscode` folder is un-un-ignored, as it wasn’t previously ignored.

