### PR TITLE
chore: remove legacy-peer-deps from .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-legacy-peer-deps = true
 package-lock = false


### PR DESCRIPTION
Previously this was needed due to some problematic dependencies. We no longer have those dependencies.