### PR TITLE
Support remark plugins in the language server

### DIFF
--- a/.changeset/remark-syntax-plugins.md
+++ b/.changeset/remark-syntax-plugins.md
@@ -1,0 +1,33 @@
+---
+vscode-mdx: minor
+---
+
+Support remark syntax plugins.
+
+Syntax plugins can be added by adding an `mdx` section in your `tsconfig.json`
+file.
+This is then parsed following the same format as `unified-engine`
+[configuration][].
+
+For example, to support [frontmatter][] and [GFM][], add the following section
+to `tsconfig.json`:
+
+```jsonc
+{
+  "compilerOptions": {
+    // …
+  },
+  "mdx": {
+    "plugins": [
+      "remark-frontmatter",
+      "remark-gfm"
+    ]
+  }
+}
+```
+
+[configuration]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
+
+[frontmatter]: https://github.com/remarkjs/remark-frontmatter
+
+[gfm]: https://github.com/remarkjs/remark-gfm

--- a/.changeset/remark-syntax-plugins.md
+++ b/.changeset/remark-syntax-plugins.md
@@ -6,7 +6,7 @@ Support remark syntax plugins.
 
 This extension supports remark syntax plugins.
 Plugins can be defined in an array of strings or string / options tuples.
-These plugins can be defined in `tsconfig.json` and will be resolve relative to
+These plugins can be defined in `tsconfig.json` and will be resolved relative to
 that file.
 
 For example, to support [frontmatter][] with YAML and TOML and [GFM][]:

--- a/.changeset/remark-syntax-plugins.md
+++ b/.changeset/remark-syntax-plugins.md
@@ -4,13 +4,12 @@ vscode-mdx: minor
 
 Support remark syntax plugins.
 
-Syntax plugins can be added by adding an `mdx` section in your `tsconfig.json`
-file.
-This is then parsed following the same format as `unified-engine`
-[configuration][].
+This extension supports remark syntax plugins.
+Plugins can be defined in an array of strings or string / options tuples.
+These plugins can be defined in `tsconfig.json` and will be resolve relative to
+that file.
 
-For example, to support [frontmatter][] and [GFM][], add the following section
-to `tsconfig.json`:
+For example, to support [frontmatter][] with YAML and TOML and [GFM][]:
 
 ```jsonc
 {
@@ -19,14 +18,15 @@ to `tsconfig.json`:
   },
   "mdx": {
     "plugins": [
-      "remark-frontmatter",
+      [
+        "remark-frontmatter",
+        ["toml", "yaml"]
+      ],
       "remark-gfm"
     ]
   }
 }
 ```
-
-[configuration]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
 
 [frontmatter]: https://github.com/remarkjs/remark-frontmatter
 

--- a/fixtures/frontmatter/frontmatter.mdx
+++ b/fixtures/frontmatter/frontmatter.mdx
@@ -1,0 +1,6 @@
+---
+author: { name: Remco }
+---
+
+Without `remark-frontmatter` this would cause a parsing error, because anything
+between curly braces (e.g. {props.value}) would be parsed using acorn.

--- a/fixtures/frontmatter/tsconfig.json
+++ b/fixtures/frontmatter/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "jsx": "react-jsx",
+    "lib": ["dom", "es2020"],
+    "module": "node16",
+    "strict": true
+  },
+  "mdx": {
+    "plugins": ["remark-frontmatter"]
+  }
+}

--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -54,6 +54,34 @@ For example:
 # Hello {props.name}
 ```
 
+## Plugins
+
+This extension supports remark syntax plugins.
+Plugins can be defined in an array of strings or string / options tuples.
+These plugins can be defined in `tsconfig.json` and will be resolve relative to
+that file.
+
+For example, to support [frontmatter][] and [GFM][]:
+
+```jsonc
+{
+  "compilerOptions": {
+    // …
+  },
+  "mdx": {
+    "plugins": [
+      [
+        "remark-frontmatter",
+        ["toml", "yaml"]
+      ],
+      "remark-gfm"
+    ]
+  }
+}
+```
+
+For a more complete list, see [remark plugins][].
+
 ## Compatibility
 
 Projects maintained by the unified collective are compatible with all maintained
@@ -91,6 +119,10 @@ abide by its terms.
 
 [contribute]: https://mdxjs.com/community/contribute/
 
+[frontmatter]: https://github.com/remarkjs/remark-frontmatter
+
+[gfm]: https://github.com/remarkjs/remark-gfm
+
 [jsdoc]: https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html
 
 [lsp]: https://microsoft.github.io/language-server-protocol
@@ -98,6 +130,8 @@ abide by its terms.
 [mdx]: https://mdxjs.com
 
 [mit]: LICENSE
+
+[remark plugins]: https://github.com/remarkjs/remark/blob/main/doc/plugins.md
 
 [support]: https://mdxjs.com/community/support/
 

--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -58,7 +58,7 @@ For example:
 
 This extension supports remark syntax plugins.
 Plugins can be defined in an array of strings or string / options tuples.
-These plugins can be defined in `tsconfig.json` and will be resolve relative to
+These plugins can be defined in `tsconfig.json` and will be resolved relative to
 that file.
 
 For example, to support [frontmatter][] with YAML and TOML and [GFM][]:

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -133,7 +133,7 @@ connection.onCompletionResolve(async (parameters) => {
 })
 
 connection.onDefinition(async (parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return
@@ -149,7 +149,7 @@ connection.onDefinition(async (parameters) => {
 })
 
 connection.onTypeDefinition(async (parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return
@@ -165,7 +165,7 @@ connection.onTypeDefinition(async (parameters) => {
 })
 
 connection.onDocumentSymbol(async (parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return
@@ -178,7 +178,7 @@ connection.onDocumentSymbol(async (parameters) => {
 })
 
 connection.onFoldingRanges(async (parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return
@@ -201,7 +201,7 @@ connection.onFoldingRanges(async (parameters) => {
 })
 
 connection.onHover(async (parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return
@@ -233,7 +233,7 @@ connection.onHover(async (parameters) => {
 })
 
 connection.onReferences(async (parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return
@@ -252,7 +252,7 @@ connection.onReferences(async (parameters) => {
 })
 
 connection.onPrepareRename(async (parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return
@@ -271,7 +271,7 @@ connection.onPrepareRename(async (parameters) => {
 })
 
 connection.onRenameRequest(async (parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -55,7 +55,7 @@ connection.onInitialize(() => {
   }
 })
 
-connection.onCompletion((parameters) => {
+connection.onCompletion(async (parameters) => {
   const doc = documents.get(parameters.textDocument.uri)
 
   if (!doc) {
@@ -63,7 +63,7 @@ connection.onCompletion((parameters) => {
   }
 
   const offset = doc.offsetAt(parameters.position)
-  const ls = getOrCreateLanguageService(ts, doc.uri)
+  const ls = await getOrCreateLanguageService(ts, doc.uri)
   const info = ls.getCompletionsAtPosition(fileURLToPath(doc.uri), offset, {
     triggerKind: parameters.context?.triggerKind,
     triggerCharacter: /** @type {ts.CompletionsTriggerCharacter} */ (
@@ -96,7 +96,7 @@ connection.onCompletion((parameters) => {
   }
 })
 
-connection.onCompletionResolve((parameters) => {
+connection.onCompletionResolve(async (parameters) => {
   const {data, offset, source, uri} = parameters.data
 
   const doc = documents.get(uri)
@@ -105,7 +105,7 @@ connection.onCompletionResolve((parameters) => {
     return parameters
   }
 
-  const ls = getOrCreateLanguageService(ts, uri)
+  const ls = await getOrCreateLanguageService(ts, uri)
   const details = ls.getCompletionEntryDetails(
     fileURLToPath(uri),
     offset,
@@ -132,14 +132,14 @@ connection.onCompletionResolve((parameters) => {
   }
 })
 
-connection.onDefinition((parameters) => {
+connection.onDefinition(async (parameters) => {
   const doc = documents.get(parameters.textDocument.uri)
 
   if (!doc) {
     return
   }
 
-  const ls = getOrCreateLanguageService(ts, doc.uri)
+  const ls = await getOrCreateLanguageService(ts, doc.uri)
   const entries = ls.getDefinitionAtPosition(
     fileURLToPath(doc.uri),
     doc.offsetAt(parameters.position)
@@ -148,14 +148,14 @@ connection.onDefinition((parameters) => {
   return definitionInfoToLocationLinks(entries)
 })
 
-connection.onTypeDefinition((parameters) => {
+connection.onTypeDefinition(async (parameters) => {
   const doc = documents.get(parameters.textDocument.uri)
 
   if (!doc) {
     return
   }
 
-  const ls = getOrCreateLanguageService(ts, doc.uri)
+  const ls = await getOrCreateLanguageService(ts, doc.uri)
   const entries = ls.getTypeDefinitionAtPosition(
     fileURLToPath(doc.uri),
     doc.offsetAt(parameters.position)
@@ -164,27 +164,27 @@ connection.onTypeDefinition((parameters) => {
   return definitionInfoToLocationLinks(entries)
 })
 
-connection.onDocumentSymbol((parameters) => {
+connection.onDocumentSymbol(async (parameters) => {
   const doc = documents.get(parameters.textDocument.uri)
 
   if (!doc) {
     return
   }
 
-  const ls = getOrCreateLanguageService(ts, doc.uri)
+  const ls = await getOrCreateLanguageService(ts, doc.uri)
   const navigationBarItems = ls.getNavigationBarItems(fileURLToPath(doc.uri))
 
   return convertNavigationBarItems(doc, navigationBarItems)
 })
 
-connection.onFoldingRanges((parameters) => {
+connection.onFoldingRanges(async (parameters) => {
   const doc = documents.get(parameters.textDocument.uri)
 
   if (!doc) {
     return
   }
 
-  const ls = getOrCreateLanguageService(ts, doc.uri)
+  const ls = await getOrCreateLanguageService(ts, doc.uri)
   const outlineSpans = ls.getOutliningSpans(fileURLToPath(doc.uri))
 
   return outlineSpans.map((span) => {
@@ -200,14 +200,14 @@ connection.onFoldingRanges((parameters) => {
   })
 })
 
-connection.onHover((parameters) => {
+connection.onHover(async (parameters) => {
   const doc = documents.get(parameters.textDocument.uri)
 
   if (!doc) {
     return
   }
 
-  const ls = getOrCreateLanguageService(ts, doc.uri)
+  const ls = await getOrCreateLanguageService(ts, doc.uri)
   const info = ls.getQuickInfoAtPosition(
     fileURLToPath(doc.uri),
     doc.offsetAt(parameters.position)
@@ -232,14 +232,14 @@ connection.onHover((parameters) => {
   }
 })
 
-connection.onReferences((parameters) => {
+connection.onReferences(async (parameters) => {
   const doc = documents.get(parameters.textDocument.uri)
 
   if (!doc) {
     return
   }
 
-  const ls = getOrCreateLanguageService(ts, doc.uri)
+  const ls = await getOrCreateLanguageService(ts, doc.uri)
   const entries = ls.getReferencesAtPosition(
     fileURLToPath(doc.uri),
     doc.offsetAt(parameters.position)
@@ -251,7 +251,7 @@ connection.onReferences((parameters) => {
   }))
 })
 
-connection.onPrepareRename((parameters) => {
+connection.onPrepareRename(async (parameters) => {
   const doc = documents.get(parameters.textDocument.uri)
 
   if (!doc) {
@@ -260,7 +260,7 @@ connection.onPrepareRename((parameters) => {
 
   const fileName = fileURLToPath(doc.uri)
   const position = doc.offsetAt(parameters.position)
-  const ls = getOrCreateLanguageService(ts, doc.uri)
+  const ls = await getOrCreateLanguageService(ts, doc.uri)
   const renameInfo = ls.getRenameInfo(fileName, position, {
     allowRenameOfImportPath: false
   })
@@ -270,7 +270,7 @@ connection.onPrepareRename((parameters) => {
   }
 })
 
-connection.onRenameRequest((parameters) => {
+connection.onRenameRequest(async (parameters) => {
   const doc = documents.get(parameters.textDocument.uri)
 
   if (!doc) {
@@ -279,7 +279,7 @@ connection.onRenameRequest((parameters) => {
 
   const fileName = fileURLToPath(doc.uri)
   const position = doc.offsetAt(parameters.position)
-  const ls = getOrCreateLanguageService(ts, doc.uri)
+  const ls = await getOrCreateLanguageService(ts, doc.uri)
   const locations = ls.findRenameLocations(fileName, position, false, false)
 
   if (!locations?.length) {
@@ -314,10 +314,10 @@ documents.onDidClose((event) => {
 /**
  * @param {TextDocumentChangeEvent} event
  */
-function checkDiagnostics(event) {
+async function checkDiagnostics(event) {
   const {uri} = event.document
   const path = fileURLToPath(uri)
-  const ls = getOrCreateLanguageService(ts, uri)
+  const ls = await getOrCreateLanguageService(ts, uri)
   const diagnostics = [
     ...ls.getSemanticDiagnostics(path),
     ...ls.getSuggestionDiagnostics(path),

--- a/packages/language-server/lib/configuration.js
+++ b/packages/language-server/lib/configuration.js
@@ -1,0 +1,61 @@
+/**
+ * @typedef {import('unified').Pluggable} Pluggable
+ * @typedef {import('unified').PluggableList} PluggableList
+ */
+
+import {loadPlugin} from 'load-plugin'
+
+/**
+ * Load remark plugins from a configuration object.
+ *
+ * @param {string} cwd
+ *   The current working directory to resolve plugins from.
+ * @param {unknown} config
+ *   The object that defines the configuration.
+ * @returns {Promise<PluggableList | undefined>}
+ *   A list of unified plugins to use.
+ */
+export async function loadPlugins(cwd, config) {
+  if (typeof config !== 'object') {
+    return
+  }
+
+  if (!config) {
+    return
+  }
+
+  if (!('plugins' in config)) {
+    return
+  }
+
+  let pluginConfig = config.plugins
+
+  if (typeof pluginConfig !== 'object') {
+    return
+  }
+
+  if (!pluginConfig) {
+    return
+  }
+
+  const pluginArray = Array.isArray(pluginConfig)
+    ? pluginConfig
+    : Object.entries(pluginConfig)
+
+  /** @type {Promise<Pluggable>[]} */
+  const plugins = []
+  for (const maybeTuple of pluginArray) {
+    const [name, ...options] = /** @type {unknown[]} */ ([]).concat(maybeTuple)
+
+    if (typeof name !== 'string') {
+      continue
+    }
+
+    plugins.push(
+      loadPlugin(name, {prefix: 'remark', cwd}).then(
+        (plugin) => /** @type {Pluggable} */ ([plugin, ...options])
+      )
+    )
+  }
+  return Promise.all(plugins)
+}

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@mdx-js/language-service": "0.0.0",
+    "load-plugin": "^5.0.0",
     "vscode-languageserver": "^8.0.0",
     "vscode-languageserver-textdocument": "^1.0.0"
   },

--- a/packages/language-server/tests/plugins.test.js
+++ b/packages/language-server/tests/plugins.test.js
@@ -1,0 +1,44 @@
+/**
+ * @typedef {import('vscode-languageserver').ProtocolConnection} ProtocolConnection
+ */
+import assert from 'node:assert/strict'
+import {afterEach, beforeEach, test} from 'node:test'
+
+import {InitializeRequest} from 'vscode-languageserver'
+
+import {
+  createConnection,
+  openTextDocument,
+  waitForDiagnostics
+} from './utils.js'
+
+/** @type {ProtocolConnection} */
+let connection
+
+beforeEach(() => {
+  connection = createConnection()
+})
+
+afterEach(() => {
+  connection.dispose()
+})
+
+test('frontmatter', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const diagnosticsParamsPromise = waitForDiagnostics(connection)
+  const textDocument = await openTextDocument(
+    connection,
+    'frontmatter/frontmatter.mdx'
+  )
+  const diagnosticsParams = await diagnosticsParamsPromise
+
+  assert.deepEqual(diagnosticsParams, {
+    diagnostics: [],
+    uri: textDocument.uri
+  })
+})

--- a/packages/language-server/tests/utils.js
+++ b/packages/language-server/tests/utils.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('vscode-languageserver').TextDocumentItem} TextDocumentItem
  * @typedef {import('vscode-languageserver').ProtocolConnection} ProtocolConnection
+ * @typedef {import('vscode-languageserver').PublishDiagnosticsParams} PublishDiagnosticsParams
  */
 
 import {spawn} from 'node:child_process'
@@ -10,7 +11,8 @@ import {
   createProtocolConnection,
   DidOpenTextDocumentNotification,
   IPCMessageReader,
-  IPCMessageWriter
+  IPCMessageWriter,
+  PublishDiagnosticsNotification
 } from 'vscode-languageserver/node.js'
 
 const TEST_TIMEOUT = 10e3
@@ -77,4 +79,14 @@ export async function openTextDocument(connection, fileName) {
   })
 
   return textDocument
+}
+
+/**
+ * @param {ProtocolConnection} connection
+ * @returns {Promise<PublishDiagnosticsParams>}
+ */
+export function waitForDiagnostics(connection) {
+  return new Promise((resolve) => {
+    connection.onNotification(PublishDiagnosticsNotification.type, resolve)
+  })
 }

--- a/packages/vscode-mdx/README.md
+++ b/packages/vscode-mdx/README.md
@@ -19,6 +19,34 @@ This extension provides the following settings:
 *   `mdx.experimentalLanguageServer`: Enable experimental IntelliSense support
     for MDX files.  (`boolean`, default: false)
 
+## Plugins
+
+This extension supports remark syntax plugins.
+Plugins can be defined in an array of strings or string / options tuples.
+These plugins can be defined in `tsconfig.json` and will be resolve relative to
+that file.
+
+For example, to support [frontmatter][] with YAML and TOML and [GFM][]:
+
+```jsonc
+{
+  "compilerOptions": {
+    // …
+  },
+  "mdx": {
+    "plugins": [
+      [
+        "remark-frontmatter",
+        ["toml", "yaml"]
+      ],
+      "remark-gfm"
+    ]
+  }
+}
+```
+
+For a more complete list, see [remark plugins][].
+
 ## Integration With [VS Code ESLint](https://github.com/microsoft/vscode-eslint)
 
 1.  First of all, you need to enable [eslint-plugin-mdx][] which makes it
@@ -187,6 +215,10 @@ Detailed changes for each release are documented in [CHANGELOG.md](./CHANGELOG.m
 
 [eslint-plugin-mdx]: https://github.com/mdx-js/eslint-mdx
 
+[frontmatter]: https://github.com/remarkjs/remark-frontmatter
+
+[gfm]: https://github.com/remarkjs/remark-gfm
+
 [jounqin]: https://GitHub.com/JounQin
 
 [mdx]: https://github.com/mdx-js/mdx
@@ -196,5 +228,7 @@ Detailed changes for each release are documented in [CHANGELOG.md](./CHANGELOG.m
 [remark]: https://github.com/remarkjs/remark
 
 [remark-lint]: https://github.com/remarkjs/remark-lint
+
+[remark plugins]: https://github.com/remarkjs/remark/blob/main/doc/plugins.md
 
 [sponsor]: https://mdxjs.com/community/sponsor/

--- a/packages/vscode-mdx/README.md
+++ b/packages/vscode-mdx/README.md
@@ -23,7 +23,7 @@ This extension provides the following settings:
 
 This extension supports remark syntax plugins.
 Plugins can be defined in an array of strings or string / options tuples.
-These plugins can be defined in `tsconfig.json` and will be resolve relative to
+These plugins can be defined in `tsconfig.json` and will be resolved relative to
 that file.
 
 For example, to support [frontmatter][] with YAML and TOML and [GFM][]:

--- a/packages/vscode-mdx/package.json
+++ b/packages/vscode-mdx/package.json
@@ -76,6 +76,12 @@
         "configuration": "./language-configuration.jsonc"
       }
     ],
+    "jsonValidation": [
+      {
+        "fileMatch": "tsconfig.json",
+        "url": "./tsconfig.schema.json"
+      }
+    ],
     "grammars": [
       {
         "language": "mdx",

--- a/packages/vscode-mdx/tsconfig.schema.json
+++ b/packages/vscode-mdx/tsconfig.schema.json
@@ -1,0 +1,8 @@
+{
+  "properties": {
+    "mdx": {
+      "title": "MDX language server options",
+      "$ref": "https://json.schemastore.org/remarkrc.json"
+    }
+  }
+}


### PR DESCRIPTION
Syntax plugins can be added by adding an `mdx` section in your `tsconfig.json` file. This is then parsed following the same format as `unified-engine` [configuration][].

For example, to support [frontmatter][] and [GFM][], add the following section to `tsconfig.json`:

```jsonc
{
  "compilerOptions": {
    // …
  },
  "mdx": {
    "plugins": [
      "remark-frontmatter",
      "remark-gfm"
    ]
  }
}
```

This also adds the JSON schema for the new field in `tsconfig.json`.

Closes #266