### PR TITLE
Ignore non MDX files when processing

### DIFF
--- a/.changeset/ignore-non-mdx-files.md
+++ b/.changeset/ignore-non-mdx-files.md
@@ -1,0 +1,11 @@
+---
+vscode-mdx: patch
+---
+
+Previously the MDX language server handled TypeScript IntelliSense for
+JavaScript and TypeScript files as well.
+This led to duplicate IntelliSense results in the editor if people have also
+enabled TypeScript IntelliSense.
+
+These files are still synchronized with the MDX language server, because they
+are needed for context, but they no longer yield results when interacted with.

--- a/fixtures/node16/component.tsx
+++ b/fixtures/node16/component.tsx
@@ -1,0 +1,8 @@
+/**
+ * Interacting with this file should not trigger any results.
+ *
+ * If you see this text in a test, it means the test failed!
+ */
+function Component() {}
+
+export {Component}

--- a/fixtures/node16/component.tsx
+++ b/fixtures/node16/component.tsx
@@ -3,6 +3,8 @@
  *
  * If you see this text in a test, it means the test failed!
  */
-function Component() {}
+function Component() {
+  return 42
+}
 
 export {Component}

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -25,7 +25,7 @@ import {
   definitionInfoToLocationLinks,
   textSpanToRange
 } from './lib/convert.js'
-import {documents, getDocByFileName} from './lib/documents.js'
+import {documents, getDocByFileName, getMdxDoc} from './lib/documents.js'
 import {getOrCreateLanguageService} from './lib/language-service-manager.js'
 
 process.title = 'mdx-language-server'
@@ -56,10 +56,10 @@ connection.onInitialize(() => {
 })
 
 connection.onCompletion((parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
-    return []
+    return
   }
 
   const offset = doc.offsetAt(parameters.position)
@@ -72,7 +72,7 @@ connection.onCompletion((parameters) => {
   })
 
   if (!info) {
-    return []
+    return
   }
 
   return {
@@ -99,7 +99,7 @@ connection.onCompletion((parameters) => {
 connection.onCompletionResolve((parameters) => {
   const {data, offset, source, uri} = parameters.data
 
-  const doc = documents.get(uri)
+  const doc = getMdxDoc(uri)
 
   if (!doc) {
     return parameters
@@ -133,7 +133,7 @@ connection.onCompletionResolve((parameters) => {
 })
 
 connection.onDefinition((parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return
@@ -149,7 +149,7 @@ connection.onDefinition((parameters) => {
 })
 
 connection.onTypeDefinition((parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return
@@ -165,7 +165,7 @@ connection.onTypeDefinition((parameters) => {
 })
 
 connection.onDocumentSymbol((parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return
@@ -178,7 +178,7 @@ connection.onDocumentSymbol((parameters) => {
 })
 
 connection.onFoldingRanges((parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return
@@ -201,7 +201,7 @@ connection.onFoldingRanges((parameters) => {
 })
 
 connection.onHover((parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return
@@ -233,7 +233,7 @@ connection.onHover((parameters) => {
 })
 
 connection.onReferences((parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return
@@ -252,7 +252,7 @@ connection.onReferences((parameters) => {
 })
 
 connection.onPrepareRename((parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return
@@ -271,7 +271,7 @@ connection.onPrepareRename((parameters) => {
 })
 
 connection.onRenameRequest((parameters) => {
-  const doc = documents.get(parameters.textDocument.uri)
+  const doc = getMdxDoc(parameters.textDocument.uri)
 
   if (!doc) {
     return

--- a/packages/language-server/lib/documents.js
+++ b/packages/language-server/lib/documents.js
@@ -1,5 +1,6 @@
 import {pathToFileURL} from 'node:url'
 
+import {isMdx} from '@mdx-js/language-service'
 import {TextDocuments} from 'vscode-languageserver'
 import {TextDocument} from 'vscode-languageserver-textdocument'
 
@@ -13,11 +14,25 @@ export const documents = new TextDocuments(TextDocument)
  *
  * Documents are stored using a file URL. This function allows to do a lookup by file name instead.
  *
- * @param {string } fileName
+ * @param {string} fileName
  *   The file name to lookup.
  * @returns {TextDocument | undefined}
  *   The text document that matches the filename.
  */
 export function getDocByFileName(fileName) {
   return documents.get(String(pathToFileURL(fileName)))
+}
+
+/**
+ * Get a document, but only if it’s an MDX document.
+ *
+ * @param {string} uri
+ *   The file URL of the document.
+ * @returns {TextDocument | undefined}
+ *   The MDX text document that matches the given URI, if it exists.
+ */
+export function getMdxDoc(uri) {
+  if (isMdx(uri)) {
+    return documents.get(uri)
+  }
 }

--- a/packages/language-server/tests/definitions.test.js
+++ b/packages/language-server/tests/definitions.test.js
@@ -143,7 +143,7 @@ test('ignore non-existent mdx files', async () => {
     capabilities: {}
   })
 
-  const {uri} = await openTextDocument(connection, 'node16/non-existent.mdx')
+  const uri = fixtureUri('node16/non-existent.mdx')
   const result = await connection.sendRequest(DefinitionRequest.type, {
     position: {line: 7, character: 15},
     textDocument: {uri}

--- a/packages/language-server/tests/definitions.test.js
+++ b/packages/language-server/tests/definitions.test.js
@@ -135,3 +135,35 @@ test('resolve markdown link references', async () => {
     }
   ])
 })
+
+test('ignore non-existent mdx files', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/non-existent.mdx')
+  const result = await connection.sendRequest(DefinitionRequest.type, {
+    position: {line: 7, character: 15},
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
+})
+
+test('ignore non-mdx files', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/component.tsx')
+  const result = await connection.sendRequest(DefinitionRequest.type, {
+    position: {line: 7, character: 15},
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
+})

--- a/packages/language-server/tests/definitions.test.js
+++ b/packages/language-server/tests/definitions.test.js
@@ -161,7 +161,7 @@ test('ignore non-mdx files', async () => {
 
   const {uri} = await openTextDocument(connection, 'node16/component.tsx')
   const result = await connection.sendRequest(DefinitionRequest.type, {
-    position: {line: 7, character: 15},
+    position: {line: 9, character: 15},
     textDocument: {uri}
   })
 

--- a/packages/language-server/tests/document-symbols.test.js
+++ b/packages/language-server/tests/document-symbols.test.js
@@ -10,7 +10,7 @@ import {
   SymbolKind
 } from 'vscode-languageserver'
 
-import {createConnection, openTextDocument} from './utils.js'
+import {createConnection, fixtureUri, openTextDocument} from './utils.js'
 
 /** @type {ProtocolConnection} */
 let connection
@@ -59,7 +59,7 @@ test('ignore non-existent mdx files', async () => {
     capabilities: {}
   })
 
-  const {uri} = await openTextDocument(connection, 'node16/non-existent.mdx')
+  const uri = fixtureUri('node16/non-existent.mdx')
   const result = await connection.sendRequest(DocumentSymbolRequest.type, {
     textDocument: {uri}
   })

--- a/packages/language-server/tests/document-symbols.test.js
+++ b/packages/language-server/tests/document-symbols.test.js
@@ -51,3 +51,33 @@ test('resolve document symbols', async () => {
     }
   ])
 })
+
+test('ignore non-existent mdx files', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/non-existent.mdx')
+  const result = await connection.sendRequest(DocumentSymbolRequest.type, {
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
+})
+
+test('ignore non-mdx files', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/component.tsx')
+  const result = await connection.sendRequest(DocumentSymbolRequest.type, {
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
+})

--- a/packages/language-server/tests/hover.test.js
+++ b/packages/language-server/tests/hover.test.js
@@ -146,3 +146,35 @@ test('resolve import hover in JSX elements', async () => {
     }
   })
 })
+
+test('ignore non-existent mdx files', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/non-existent.mdx')
+  const result = await connection.sendRequest(HoverRequest.type, {
+    position: {line: 7, character: 15},
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
+})
+
+test('ignore non-mdx files', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/component.tsx')
+  const result = await connection.sendRequest(HoverRequest.type, {
+    position: {line: 7, character: 15},
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
+})

--- a/packages/language-server/tests/hover.test.js
+++ b/packages/language-server/tests/hover.test.js
@@ -172,7 +172,7 @@ test('ignore non-mdx files', async () => {
 
   const {uri} = await openTextDocument(connection, 'node16/component.tsx')
   const result = await connection.sendRequest(HoverRequest.type, {
-    position: {line: 7, character: 15},
+    position: {line: 9, character: 15},
     textDocument: {uri}
   })
 

--- a/packages/language-server/tests/hover.test.js
+++ b/packages/language-server/tests/hover.test.js
@@ -6,7 +6,7 @@ import {afterEach, beforeEach, test} from 'node:test'
 
 import {HoverRequest, InitializeRequest} from 'vscode-languageserver'
 
-import {createConnection, openTextDocument} from './utils.js'
+import {createConnection, fixtureUri, openTextDocument} from './utils.js'
 
 /** @type {ProtocolConnection} */
 let connection
@@ -154,7 +154,7 @@ test('ignore non-existent mdx files', async () => {
     capabilities: {}
   })
 
-  const {uri} = await openTextDocument(connection, 'node16/non-existent.mdx')
+  const uri = fixtureUri('node16/non-existent.mdx')
   const result = await connection.sendRequest(HoverRequest.type, {
     position: {line: 7, character: 15},
     textDocument: {uri}

--- a/packages/language-server/tests/prepare-rename.test.js
+++ b/packages/language-server/tests/prepare-rename.test.js
@@ -79,7 +79,7 @@ test('ignore non-mdx files', async () => {
 
   const {uri} = await openTextDocument(connection, 'node16/component.tsx')
   const result = await connection.sendRequest(PrepareRenameRequest.type, {
-    position: {line: 7, character: 15},
+    position: {line: 9, character: 15},
     textDocument: {uri}
   })
 

--- a/packages/language-server/tests/prepare-rename.test.js
+++ b/packages/language-server/tests/prepare-rename.test.js
@@ -53,3 +53,35 @@ test('handle unknown rename request', async () => {
 
   assert.deepEqual(result, null)
 })
+
+test('ignore non-existent mdx files', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/non-existent.mdx')
+  const result = await connection.sendRequest(PrepareRenameRequest.type, {
+    position: {line: 7, character: 15},
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
+})
+
+test('ignore non-mdx files', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/component.tsx')
+  const result = await connection.sendRequest(PrepareRenameRequest.type, {
+    position: {line: 7, character: 15},
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
+})

--- a/packages/language-server/tests/prepare-rename.test.js
+++ b/packages/language-server/tests/prepare-rename.test.js
@@ -6,7 +6,7 @@ import {afterEach, beforeEach, test} from 'node:test'
 
 import {InitializeRequest, PrepareRenameRequest} from 'vscode-languageserver'
 
-import {createConnection, openTextDocument} from './utils.js'
+import {createConnection, fixtureUri, openTextDocument} from './utils.js'
 
 /** @type {ProtocolConnection} */
 let connection
@@ -61,7 +61,7 @@ test('ignore non-existent mdx files', async () => {
     capabilities: {}
   })
 
-  const {uri} = await openTextDocument(connection, 'node16/non-existent.mdx')
+  const uri = fixtureUri('node16/non-existent.mdx')
   const result = await connection.sendRequest(PrepareRenameRequest.type, {
     position: {line: 7, character: 15},
     textDocument: {uri}

--- a/packages/language-server/tests/rename.test.js
+++ b/packages/language-server/tests/rename.test.js
@@ -33,7 +33,6 @@ test('handle rename request of variable for opened references', async () => {
     textDocument: {uri}
   })
 
-  console.dir(result, {depth: Number.POSITIVE_INFINITY})
   assert.deepEqual(result, {
     changes: {
       [fixtureUri('node16/a.mdx')]: [
@@ -76,4 +75,38 @@ test('handle rename request of variable for opened references', async () => {
       ]
     }
   })
+})
+
+test('ignore non-existent mdx files', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/non-existent.mdx')
+  const result = await connection.sendRequest(RenameRequest.type, {
+    newName: 'renamed',
+    position: {line: 7, character: 15},
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
+})
+
+test('ignore non-mdx files', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/component.tsx')
+  const result = await connection.sendRequest(RenameRequest.type, {
+    newName: 'renamed',
+    position: {line: 7, character: 15},
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
 })

--- a/packages/language-server/tests/rename.test.js
+++ b/packages/language-server/tests/rename.test.js
@@ -104,7 +104,7 @@ test('ignore non-mdx files', async () => {
   const {uri} = await openTextDocument(connection, 'node16/component.tsx')
   const result = await connection.sendRequest(RenameRequest.type, {
     newName: 'renamed',
-    position: {line: 7, character: 15},
+    position: {line: 9, character: 15},
     textDocument: {uri}
   })
 

--- a/packages/language-server/tests/rename.test.js
+++ b/packages/language-server/tests/rename.test.js
@@ -84,7 +84,7 @@ test('ignore non-existent mdx files', async () => {
     capabilities: {}
   })
 
-  const {uri} = await openTextDocument(connection, 'node16/non-existent.mdx')
+  const uri = fixtureUri('node16/non-existent.mdx')
   const result = await connection.sendRequest(RenameRequest.type, {
     newName: 'renamed',
     position: {line: 7, character: 15},

--- a/packages/language-service/index.js
+++ b/packages/language-service/index.js
@@ -1,1 +1,1 @@
-export {createMdxLanguageService} from './lib/index.js'
+export {createMdxLanguageService, isMdx} from './lib/index.js'

--- a/packages/language-service/lib/index.js
+++ b/packages/language-service/lib/index.js
@@ -32,7 +32,7 @@ import {mdxToJsx, unistPositionToTextSpan} from './utils.js'
  * @returns {fileName is `${string}.mdx`}
  *   Whether or not the filename contains MDX.
  */
-function isMdx(fileName) {
+export function isMdx(fileName) {
   return fileName.endsWith('.mdx')
 }
 

--- a/packages/vscode-mdx/package.json
+++ b/packages/vscode-mdx/package.json
@@ -30,8 +30,11 @@
   ],
   "icon": "assets/mdx.png",
   "activationEvents": [
+    "onLanguage:javascript",
+    "onLanguage:javascriptreact",
     "onLanguage:mdx",
-    "onLanguage:typescript"
+    "onLanguage:typescript",
+    "onLanguage:typescriptreact"
   ],
   "vsce": {
     "dependencies": false


### PR DESCRIPTION
Previously the MDX language server handled TypeScript IntelliSense for JavaScript and TypeScript files as well. This led to duplicate IntelliSense results in the editor if people have also enabled TypeScript IntelliSense.

These files are still synchronized with the MDX language server, because they are needed for context, but they no longer yield results when interacted with.

This also adds tests for when a document does not exist.

Closes #270
