### PR TITLE
Remove names and excessive whitespace from workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,12 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{matrix.node}}
       - run: npm install
       - run: npx playwright install --with-deps
       - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,33 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-
-      - name: Install Dependencies
-        run: npm install
-
+      - run: npm install
       - run: npx --workspace vscode-mdx vsce package --out "$PWD"
-
-      - name: ovsx publish
-        run: npx ovsx publish --packagePath *.vsix
+      - run: npx ovsx publish --packagePath *.vsix
         env:
           OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
-
-      - name: vsce publish
-        run: npx vsce publish --packagePath *.vsix
+      - run: npx vsce publish --packagePath *.vsix
         env:
           VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
-
       - uses: actions/upload-artifact@v3
         with:
           name: vscode-mdx.vsix
           path: ${{ steps.ovsx_publish.outputs.vsixPath }}
-
-      - name: upload vsix to release
-        uses: svenstaro/upload-release-action@v2
+      - uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ steps.ovsx_publish.outputs.vsixPath }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,17 +18,17 @@ jobs:
       - run: npx --workspace vscode-mdx vsce package --out "$PWD"
       - run: npx ovsx publish --packagePath *.vsix
         env:
-          OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
+          OVSX_PAT: ${{secrets.OPEN_VSX_TOKEN}}
       - run: npx vsce publish --packagePath *.vsix
         env:
-          VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
+          VSCE_PAT: ${{secrets.VSCE_TOKEN}}
       - uses: actions/upload-artifact@v3
         with:
           name: vscode-mdx.vsix
-          path: ${{ steps.ovsx_publish.outputs.vsixPath }}
+          path: ${{steps.ovsx_publish.outputs.vsixPath}}
       - uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ steps.ovsx_publish.outputs.vsixPath }}
+          file: ${{steps.ovsx_publish.outputs.vsixPath}}
           asset_name: vscode-mdx.vsix
-          tag: ${{ github.ref }}
+          tag: ${{github.ref}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: softprops/action-gh-release@v1
         with:
-          body_path: ${{ github.workspace }}/CHANGELOG.md
+          body_path: ${{github.workspace}}/CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
+      - uses: actions/checkout@v3
+      - uses: softprops/action-gh-release@v1
         with:
           body_path: ${{ github.workspace }}/CHANGELOG.md

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -10,22 +10,15 @@ jobs:
     name: Version
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
-
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-
-      - name: Install Dependencies
-        run: npm install
-
-      - name: Create Release Pull Request
-        id: changesets
-        uses: changesets/action@v1
+      - run: npm install
+      - uses: changesets/action@v1
         with:
           publish: git push --follow-tags
           commit: 'chore: release vscode-mdx'

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{matrix.node}}
       - run: npm install
       - uses: changesets/action@v1
         with:
@@ -24,4 +24,4 @@ jobs:
           commit: 'chore: release vscode-mdx'
           title: 'chore: release vscode-mdx'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
The `name` property is used for GitHub actions output, but in my opinion the command run often describes it better than a given name.
