### PR TITLE
Remove comments from JSON files

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,3 @@
-// A launch configuration that compiles the extension and then opens it inside a new window
-// Use IntelliSense to learn about possible attributes.
-// Hover to view descriptions of existing attributes.
-// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
   "version": "0.2.0",
   "configurations": [

--- a/packages/vscode-mdx/language-configuration.json
+++ b/packages/vscode-mdx/language-configuration.json
@@ -2,13 +2,11 @@
   "comments": {
     "blockComment": ["{/*", "*/}"]
   },
-  // symbols used as brackets
   "brackets": [
     ["{", "}"],
     ["[", "]"],
     ["(", ")"]
   ],
-  // symbols that are auto closed when typing
   "autoClosingPairs": [
     ["{", "}"],
     ["[", "]"],
@@ -40,7 +38,6 @@
       "notIn": ["string", "comment"]
     }
   ],
-  // symbols that that can be used to surround a selection
   "surroundingPairs": [
     ["{", "}"],
     ["[", "]"],

--- a/packages/vscode-mdx/package.json
+++ b/packages/vscode-mdx/package.json
@@ -73,7 +73,7 @@
         "extensions": [
           ".mdx"
         ],
-        "configuration": "./language-configuration.jsonc"
+        "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [


### PR DESCRIPTION
I just find comments in JSON weird.

Also VSCode has builtin file support for files names `language-configuration.json`, but not for `language-configuration.jsonc`.