### PR TITLE
Fix crash if file is not in the TypeScript project

### DIFF
--- a/.changeset/fix-crash.md
+++ b/.changeset/fix-crash.md
@@ -1,0 +1,11 @@
+---
+vscode-mdx: patch
+---
+
+Fix a crash that occurs if:
+
+*   no `tsconfig.json` exists.
+*   `tsconfig.json` specifies `includes`, but doesn’t include the MDX file.
+*   `tsconfig.json` specifies `excludes` and excludes the MDX file.
+*   a new file is created.
+*   a file is renamed.

--- a/fixtures/fixtures.code-workspace
+++ b/fixtures/fixtures.code-workspace
@@ -3,11 +3,9 @@
     "mdx.experimentalLanguageServer": true
   },
   "folders": [
-    {
-      "path": "demo"
-    },
-    {
-      "path": "node16"
-    }
+    {"path": "demo"},
+    {"path": "frontmatter"},
+    {"path": "no-tsconfig"},
+    {"path": "node16"}
   ]
 }

--- a/fixtures/no-tsconfig/readme.mdx
+++ b/fixtures/no-tsconfig/readme.mdx
@@ -1,0 +1,3 @@
+This document is parsed using the default language service, because no `tsconfig.json` is found.
+
+{props.name}

--- a/packages/language-server/lib/configuration.js
+++ b/packages/language-server/lib/configuration.js
@@ -28,7 +28,7 @@ export async function loadPlugins(cwd, config) {
     return
   }
 
-  let pluginConfig = config.plugins
+  const pluginConfig = config.plugins
 
   if (typeof pluginConfig !== 'object') {
     return
@@ -45,7 +45,9 @@ export async function loadPlugins(cwd, config) {
   /** @type {Promise<Pluggable>[]} */
   const plugins = []
   for (const maybeTuple of pluginArray) {
-    const [name, ...options] = /** @type {unknown[]} */ ([]).concat(maybeTuple)
+    const [name, ...options] = Array.isArray(maybeTuple)
+      ? maybeTuple
+      : [maybeTuple]
 
     if (typeof name !== 'string') {
       continue
@@ -57,5 +59,6 @@ export async function loadPlugins(cwd, config) {
       )
     )
   }
+
   return Promise.all(plugins)
 }

--- a/packages/language-server/lib/language-service-manager.js
+++ b/packages/language-server/lib/language-service-manager.js
@@ -45,7 +45,7 @@ function createGetScriptSnapshot(ts) {
  *   The list of open documents.
  */
 function getScriptFileNames() {
-  return documents.keys().map(fileURLToPath)
+  return documents.keys().map((uri) => fileURLToPath(uri))
 }
 
 /**
@@ -201,5 +201,6 @@ export function getOrCreateLanguageService(ts, uri) {
     promise = createLanguageService(ts, configPath)
     cache.set(configPath, promise)
   }
+
   return promise
 }

--- a/packages/language-server/lib/language-service-manager.js
+++ b/packages/language-server/lib/language-service-manager.js
@@ -1,7 +1,10 @@
 /**
  * @typedef {import('typescript')} ts
+ * @typedef {import('typescript').CompilerOptions} CompilerOptions
  * @typedef {import('typescript').IScriptSnapshot} IScriptSnapshot
  * @typedef {import('typescript').LanguageService} LanguageService
+ * @typedef {import('typescript').LanguageServiceHost} LanguageServiceHost
+ * @typedef {import('typescript').ProjectReference} ProjectReference
  */
 
 import path from 'node:path'
@@ -10,7 +13,7 @@ import {fileURLToPath, pathToFileURL} from 'node:url'
 import {createMdxLanguageService} from '@mdx-js/language-service'
 
 import {loadPlugins} from './configuration.js'
-import {getDocByFileName} from './documents.js'
+import {documents, getDocByFileName} from './documents.js'
 
 /**
  * Create a function for getting a script snapshot based on a TypeScript module.
@@ -36,6 +39,16 @@ function createGetScriptSnapshot(ts) {
 }
 
 /**
+ * Get a list of the file paths of all open documents.
+ *
+ * @returns {string[]}
+ *   The list of open documents.
+ */
+function getScriptFileNames() {
+  return documents.keys().map(fileURLToPath)
+}
+
+/**
  * Get the current script version of a file.
  *
  * If a file has previously been opened, it will be available in the document
@@ -55,6 +68,31 @@ function getScriptVersion(fileName) {
   return doc ? String(doc.version) : '0'
 }
 
+/**
+ * Create a language service host that works with the language server.
+ *
+ * @param {ts} ts
+ *   The TypeScript module to use.
+ * @param {CompilerOptions} options
+ *   The compiler options to use.
+ * @param {readonly ProjectReference[]} [references]
+ *   The compiler options to use.
+ * @returns {LanguageServiceHost}
+ *   A language service host that works with the language server.
+ */
+function createLanguageServiceHost(ts, options, references) {
+  return {
+    ...ts.sys,
+    getCompilationSettings: () => options,
+    getDefaultLibFileName: ts.getDefaultLibFilePath,
+    getProjectReferences: () => references,
+    getScriptSnapshot: createGetScriptSnapshot(ts),
+    getScriptVersion,
+    getScriptFileNames,
+    useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames
+  }
+}
+
 /** @type {LanguageService} */
 let defaultLanguageService
 
@@ -69,25 +107,20 @@ let defaultLanguageService
  * @param {ts} ts
  *   The TypeScript module to use.
  * @returns {LanguageService}
- *   The defaul language service.
+ *   The default language service.
  */
 function getDefaultLanguageService(ts) {
   if (!defaultLanguageService) {
-    defaultLanguageService = createMdxLanguageService(ts, {
-      ...ts.sys,
-      getCompilationSettings: () => ({
+    defaultLanguageService = createMdxLanguageService(
+      ts,
+      createLanguageServiceHost(ts, {
         allowJs: true,
         lib: ['lib.es2020.full.d.ts'],
         module: ts.ModuleKind.Node16,
         moduleResolution: ts.ModuleResolutionKind.NodeJs,
         target: ts.ScriptTarget.Latest
-      }),
-      getDefaultLibFileName: ts.getDefaultLibFilePath,
-      getScriptSnapshot: createGetScriptSnapshot(ts),
-      getScriptVersion,
-      getScriptFileNames: () => [],
-      useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames
-    })
+      })
+    )
   }
 
   return defaultLanguageService
@@ -116,7 +149,7 @@ async function createLanguageService(ts, configPath) {
 
   const plugins = await loadPlugins(path.dirname(configPath), config.mdx)
 
-  const {fileNames, options, projectReferences} = ts.parseJsonConfigFileContent(
+  const {options, projectReferences} = ts.parseJsonConfigFileContent(
     config,
     ts.sys,
     fileURLToPath(new URL('.', pathToFileURL(configPath))),
@@ -134,16 +167,7 @@ async function createLanguageService(ts, configPath) {
 
   return createMdxLanguageService(
     ts,
-    {
-      ...ts.sys,
-      getCompilationSettings: () => options,
-      getDefaultLibFileName: ts.getDefaultLibFilePath,
-      getProjectReferences: () => projectReferences,
-      getScriptFileNames: () => fileNames,
-      getScriptSnapshot: createGetScriptSnapshot(ts),
-      getScriptVersion,
-      useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames
-    },
+    createLanguageServiceHost(ts, options, projectReferences),
     plugins
   )
 }

--- a/packages/language-server/tests/no-tsconfig.test.js
+++ b/packages/language-server/tests/no-tsconfig.test.js
@@ -30,14 +30,14 @@ test('no tsconfig exists', async () => {
     capabilities: {}
   })
 
-  const diagnosticsParamsPromise = waitForDiagnostics(connection)
+  const diagnosticsPromise = waitForDiagnostics(connection)
   const textDocument = await openTextDocument(
     connection,
     'no-tsconfig/readme.mdx'
   )
-  const diagnosticsParams = await diagnosticsParamsPromise
+  const diagnostics = await diagnosticsPromise
 
-  assert.deepEqual(diagnosticsParams, {
+  assert.deepEqual(diagnostics, {
     diagnostics: [],
     uri: textDocument.uri
   })

--- a/packages/language-server/tests/no-tsconfig.test.js
+++ b/packages/language-server/tests/no-tsconfig.test.js
@@ -1,0 +1,44 @@
+/**
+ * @typedef {import('vscode-languageserver').ProtocolConnection} ProtocolConnection
+ */
+import assert from 'node:assert/strict'
+import {afterEach, beforeEach, test} from 'node:test'
+
+import {InitializeRequest} from 'vscode-languageserver'
+
+import {
+  createConnection,
+  openTextDocument,
+  waitForDiagnostics
+} from './utils.js'
+
+/** @type {ProtocolConnection} */
+let connection
+
+beforeEach(() => {
+  connection = createConnection()
+})
+
+afterEach(() => {
+  connection.dispose()
+})
+
+test('no tsconfig exists', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const diagnosticsParamsPromise = waitForDiagnostics(connection)
+  const textDocument = await openTextDocument(
+    connection,
+    'no-tsconfig/readme.mdx'
+  )
+  const diagnosticsParams = await diagnosticsParamsPromise
+
+  assert.deepEqual(diagnosticsParams, {
+    diagnostics: [],
+    uri: textDocument.uri
+  })
+})

--- a/packages/language-server/tests/plugins.test.js
+++ b/packages/language-server/tests/plugins.test.js
@@ -30,14 +30,14 @@ test('frontmatter', async () => {
     capabilities: {}
   })
 
-  const diagnosticsParamsPromise = waitForDiagnostics(connection)
+  const diagnosticsPromise = waitForDiagnostics(connection)
   const textDocument = await openTextDocument(
     connection,
     'frontmatter/frontmatter.mdx'
   )
-  const diagnosticsParams = await diagnosticsParamsPromise
+  const diagnostics = await diagnosticsPromise
 
-  assert.deepEqual(diagnosticsParams, {
+  assert.deepEqual(diagnostics, {
     diagnostics: [],
     uri: textDocument.uri
   })


### PR DESCRIPTION
This affects:
- If no `tsconfig.json` exists.
- If `tsconfig.json` specifies `includes`, but doesn’t include the MDX file.
- If `tsconfig.json` specifies `excludes` and excludes the MDX file.
- If a new file is created.
- If a file is renamed.

Closes #269
