### PR TITLE
Fix error when requesting folding ranges

### DIFF
--- a/.changeset/fix-folding-ranges.md
+++ b/.changeset/fix-folding-ranges.md
@@ -1,0 +1,5 @@
+---
+vscode-mdx: patch
+---
+
+Fix error when requesting folding ranges.

--- a/fixtures/node16/mixed.mdx
+++ b/fixtures/node16/mixed.mdx
@@ -1,7 +1,7 @@
 import { a } from './a.mdx'
 
 {/*
-  * Block commens are foldable.
+  * Block comments are foldable.
   */}
 
 # Mixed content

--- a/fixtures/node16/mixed.mdx
+++ b/fixtures/node16/mixed.mdx
@@ -1,6 +1,12 @@
 import { a } from './a.mdx'
 
+{/*
+  * Block commens are foldable.
+  */}
+
 # Mixed content
+
+Paragraph
 
 export function exportedFunction(condition) {
   if (condition) {
@@ -11,6 +17,30 @@ export function exportedFunction(condition) {
 
 ## Level 2 Header
 
+Paragraph
+
 ### Level 3 Header
 
+Paragraph
+
+### Another Kevel 3 Header
+
+Paragraph
+
+###### Level 6 Heading
+
+We deliberately skip some levels here.
+
 ## Another Level 2 Header
+
+Paragraph
+
+```js
+console.log('This is a code block')
+```
+
+> This is a block quote
+>
+> ## Heading inside a block quote
+>
+> Paragraph

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -21,6 +21,7 @@ import {
 import {
   convertDiagnostics,
   convertNavigationBarItems,
+  convertOutliningSpanKind,
   convertScriptElementKind,
   createDocumentationString,
   definitionInfoToLocationLinks,
@@ -193,6 +194,7 @@ connection.onFoldingRanges(async (parameters) => {
     const end = doc.positionAt(span.textSpan.start + span.textSpan.length)
 
     return {
+      kind: convertOutliningSpanKind(ts, span.kind),
       endCharacter: end.character,
       endLine: end.line,
       startCharacter: start.character,

--- a/packages/language-server/lib/convert.js
+++ b/packages/language-server/lib/convert.js
@@ -8,6 +8,7 @@
  * @typedef {import('typescript').DiagnosticRelatedInformation} DiagnosticRelatedInformation
  * @typedef {import('typescript').JSDocTagInfo} JSDocTagInfo
  * @typedef {import('typescript').NavigationBarItem} NavigationBarItem
+ * @typedef {import('typescript').OutliningSpanKind} OutliningSpanKind
  * @typedef {import('typescript').QuickInfo} QuickInfo
  * @typedef {import('typescript').SymbolDisplayPart} SymbolDisplayPart
  * @typedef {import('typescript').ScriptElementKind} ScriptElementKind
@@ -24,6 +25,7 @@ import {
   DiagnosticSeverity,
   DiagnosticTag,
   DocumentSymbol,
+  FoldingRangeKind,
   LocationLink,
   Range,
   SymbolKind
@@ -405,4 +407,26 @@ export function convertNavigationBarItems(doc, items) {
         convertNavigationBarItems(doc, item.childItems)
       )
     })
+}
+
+/**
+ * Convert a TypeScript outlining span kind to a LSP folding range kind.
+ *
+ * @param {ts} ts
+ *   The TypeScript module to use.
+ * @param {OutliningSpanKind} kind
+ *   The TypeScript outlining span kind to convert.
+ * @returns {FoldingRangeKind}
+ *   The kind as an LSP folding range kind.
+ */
+export function convertOutliningSpanKind(ts, kind) {
+  if (kind === ts.OutliningSpanKind.Comment) {
+    return FoldingRangeKind.Comment
+  }
+
+  if (kind === ts.OutliningSpanKind.Imports) {
+    return FoldingRangeKind.Imports
+  }
+
+  return FoldingRangeKind.Region
 }

--- a/packages/language-server/tests/document-symbols.test.js
+++ b/packages/language-server/tests/document-symbols.test.js
@@ -41,12 +41,12 @@ test('resolve document symbols', async () => {
       kind: SymbolKind.Function,
       name: 'exportedFunction',
       range: {
-        end: {line: 9, character: 1},
-        start: {line: 4, character: 0}
+        end: {line: 15, character: 1},
+        start: {line: 10, character: 0}
       },
       selectionRange: {
-        end: {line: 9, character: 1},
-        start: {line: 4, character: 0}
+        end: {line: 15, character: 1},
+        start: {line: 10, character: 0}
       }
     }
   ])

--- a/packages/language-server/tests/folding-ranges.test.js
+++ b/packages/language-server/tests/folding-ranges.test.js
@@ -1,0 +1,178 @@
+/**
+ * @typedef {import('vscode-languageserver').ProtocolConnection} ProtocolConnection
+ */
+import assert from 'node:assert/strict'
+import {afterEach, beforeEach, test} from 'node:test'
+
+import {FoldingRangeRequest, InitializeRequest} from 'vscode-languageserver'
+
+import {createConnection, fixtureUri, openTextDocument} from './utils.js'
+
+/** @type {ProtocolConnection} */
+let connection
+
+beforeEach(() => {
+  connection = createConnection()
+})
+
+afterEach(() => {
+  connection.dispose()
+})
+
+test('resolve folding ranges', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/mixed.mdx')
+  const result = await connection.sendRequest(FoldingRangeRequest.type, {
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, [
+    {
+      endCharacter: 4,
+      endLine: 4,
+      kind: 'comment',
+      startCharacter: 1,
+      startLine: 2
+    },
+    {
+      endCharacter: 1,
+      endLine: 15,
+      kind: 'region',
+      startCharacter: 43,
+      startLine: 10
+    },
+    {
+      endCharacter: 3,
+      endLine: 13,
+      kind: 'region',
+      startCharacter: 16,
+      startLine: 11
+    },
+    {
+      endCharacter: 31,
+      endLine: 10,
+      kind: 'comment',
+      startCharacter: 0,
+      startLine: 0
+    },
+    {
+      endCharacter: 0,
+      endLine: 46,
+      kind: 'region',
+      startCharacter: 0,
+      startLine: 0
+    },
+    {
+      endCharacter: 0,
+      endLine: 46,
+      kind: 'region',
+      startCharacter: 0,
+      startLine: 0
+    },
+    {
+      endCharacter: 6,
+      endLine: 3,
+      kind: 'comment',
+      startCharacter: 0,
+      startLine: 0
+    },
+    {
+      endCharacter: 9,
+      endLine: 23,
+      kind: 'region',
+      startCharacter: 0,
+      startLine: 21
+    },
+    {
+      endCharacter: 38,
+      endLine: 31,
+      kind: 'region',
+      startCharacter: 0,
+      startLine: 17
+    },
+    {
+      endCharacter: 38,
+      endLine: 31,
+      kind: 'region',
+      startCharacter: 0,
+      startLine: 25
+    },
+    {
+      endCharacter: 38,
+      endLine: 31,
+      kind: 'region',
+      startCharacter: 0,
+      startLine: 29
+    },
+    {
+      endCharacter: 11,
+      endLine: 45,
+      kind: 'region',
+      startCharacter: 0,
+      startLine: 6
+    },
+    {
+      endCharacter: 11,
+      endLine: 45,
+      kind: 'region',
+      startCharacter: 0,
+      startLine: 33
+    },
+    {
+      endCharacter: 3,
+      endLine: 39,
+      kind: 'region',
+      startCharacter: 0,
+      startLine: 37
+    },
+    {
+      endCharacter: 11,
+      endLine: 45,
+      kind: 'region',
+      startCharacter: 0,
+      startLine: 41
+    },
+    {
+      endCharacter: 11,
+      endLine: 45,
+      kind: 'region',
+      startCharacter: 2,
+      startLine: 43
+    }
+  ])
+})
+
+test('ignore non-existent mdx files', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const uri = fixtureUri('node16/non-existent.mdx')
+  const result = await connection.sendRequest(FoldingRangeRequest.type, {
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
+})
+
+test('ignore non-mdx files', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/component.tsx')
+  const result = await connection.sendRequest(FoldingRangeRequest.type, {
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
+})

--- a/packages/language-server/tests/folding-ranges.test.js
+++ b/packages/language-server/tests/folding-ranges.test.js
@@ -54,7 +54,7 @@ test('resolve folding ranges', async () => {
       startLine: 11
     },
     {
-      endCharacter: 31,
+      endCharacter: 30,
       endLine: 10,
       kind: 'comment',
       startCharacter: 0,

--- a/packages/language-service/lib/outline.js
+++ b/packages/language-service/lib/outline.js
@@ -40,7 +40,7 @@ export function getFoldingRegions(ts, ast) {
       return
     }
 
-    /** @type {OutliningSpan[]} */
+    /** @type {(OutliningSpan | undefined)[]} */
     const scope = []
 
     for (const child of node.children) {
@@ -53,7 +53,9 @@ export function getFoldingRegions(ts, ast) {
       if (child.type === 'heading') {
         const index = child.depth - 1
         for (const done of scope.splice(index)) {
-          sections.push(done)
+          if (done) {
+            sections.push(done)
+          }
         }
 
         scope[index] = {
@@ -70,11 +72,17 @@ export function getFoldingRegions(ts, ast) {
       }
 
       for (const section of scope) {
-        section.textSpan.length = end - section.textSpan.start
+        if (section) {
+          section.textSpan.length = end - section.textSpan.start
+        }
       }
     }
 
-    sections.push(...scope)
+    for (const section of scope) {
+      if (section) {
+        sections.push(section)
+      }
+    }
   })
 
   return sections


### PR DESCRIPTION
Some cases caused a crash when requesting folding ranges related to markdown headings. This is fixed now.

This also adds support for folding range categories.

Also tests have been added for folding ranges.

Closes #289
