### PR TITLE
Fix various bugs related to shadow positions

### DIFF
--- a/.changeset/handle-shadow-positions.md
+++ b/.changeset/handle-shadow-positions.md
@@ -1,0 +1,5 @@
+---
+vscode-mdx: patch
+---
+
+Trim positions that can’t be mapped to the original MDX source code.

--- a/fixtures/node16/undefined-props.mdx
+++ b/fixtures/node16/undefined-props.mdx
@@ -1,0 +1,1 @@
+This prop is undefined: {props.notDefined}

--- a/packages/language-server/tests/definitions.test.js
+++ b/packages/language-server/tests/definitions.test.js
@@ -132,6 +132,22 @@ test('resolve markdown link references', async () => {
   ])
 })
 
+test('does not resolve shadow content', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/undefined-props.mdx')
+  const result = await connection.sendRequest(DefinitionRequest.type, {
+    position: {line: 0, character: 37},
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, [])
+})
+
 test('ignore non-existent mdx files', async () => {
   await connection.sendRequest(InitializeRequest.type, {
     processId: null,

--- a/packages/language-server/tests/folding-ranges.test.js
+++ b/packages/language-server/tests/folding-ranges.test.js
@@ -40,6 +40,13 @@ test('resolve folding ranges', async () => {
       startLine: 2
     },
     {
+      endCharacter: 11,
+      endLine: 45,
+      kind: 'region',
+      startCharacter: 0,
+      startLine: 6
+    },
+    {
       endCharacter: 1,
       endLine: 15,
       kind: 'region',
@@ -54,32 +61,11 @@ test('resolve folding ranges', async () => {
       startLine: 11
     },
     {
-      endCharacter: 30,
-      endLine: 10,
-      kind: 'comment',
-      startCharacter: 0,
-      startLine: 0
-    },
-    {
-      endCharacter: 0,
-      endLine: 46,
+      endCharacter: 38,
+      endLine: 31,
       kind: 'region',
       startCharacter: 0,
-      startLine: 0
-    },
-    {
-      endCharacter: 0,
-      endLine: 46,
-      kind: 'region',
-      startCharacter: 0,
-      startLine: 0
-    },
-    {
-      endCharacter: 6,
-      endLine: 3,
-      kind: 'comment',
-      startCharacter: 0,
-      startLine: 0
+      startLine: 17
     },
     {
       endCharacter: 9,
@@ -87,13 +73,6 @@ test('resolve folding ranges', async () => {
       kind: 'region',
       startCharacter: 0,
       startLine: 21
-    },
-    {
-      endCharacter: 38,
-      endLine: 31,
-      kind: 'region',
-      startCharacter: 0,
-      startLine: 17
     },
     {
       endCharacter: 38,
@@ -108,13 +87,6 @@ test('resolve folding ranges', async () => {
       kind: 'region',
       startCharacter: 0,
       startLine: 29
-    },
-    {
-      endCharacter: 11,
-      endLine: 45,
-      kind: 'region',
-      startCharacter: 0,
-      startLine: 6
     },
     {
       endCharacter: 11,

--- a/packages/language-server/tests/prepare-rename.test.js
+++ b/packages/language-server/tests/prepare-rename.test.js
@@ -54,6 +54,22 @@ test('handle unknown rename request', async () => {
   assert.deepEqual(result, null)
 })
 
+test('handle undefined prepare rename request', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/undefined-props.mdx')
+  const result = await connection.sendRequest(PrepareRenameRequest.type, {
+    position: {line: 0, character: 35},
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
+})
+
 test('ignore non-existent mdx files', async () => {
   await connection.sendRequest(InitializeRequest.type, {
     processId: null,

--- a/packages/language-server/tests/rename.test.js
+++ b/packages/language-server/tests/rename.test.js
@@ -77,6 +77,23 @@ test('handle rename request of variable for opened references', async () => {
   })
 })
 
+test('handle undefined rename request', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/undefined-props.mdx')
+  const result = await connection.sendRequest(RenameRequest.type, {
+    newName: 'renamed',
+    position: {line: 4, character: 3},
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
+})
+
 test('ignore non-existent mdx files', async () => {
   await connection.sendRequest(InitializeRequest.type, {
     processId: null,

--- a/packages/language-service/lib/utils.js
+++ b/packages/language-service/lib/utils.js
@@ -16,7 +16,7 @@
  *   returns the entire text.
  * @property {(position: number) => number | undefined} getShadowPosition
  *   Map a position from the real MDX document to the JSX shadow document.
- * @property {(shadowPosition: number) => number} getRealPosition
+ * @property {(shadowPosition: number) => number | undefined} getRealPosition
  *   Map a position from the shadow document to the real MDX document.
  * @property {unknown} [error]
  *   This is defined if a parsing error has occurred.
@@ -140,7 +140,7 @@ export function mdxToJsx(mdx, processor) {
       getLength: () => fallback.length,
 
       getShadowPosition: () => undefined,
-      getRealPosition: () => 0
+      getRealPosition: () => undefined
     }
   }
 
@@ -243,7 +243,7 @@ export function mdxToJsx(mdx, processor) {
       }
 
       if (shadowPosition <= esmShadow.length + componentStart.length) {
-        return 0
+        return
       }
 
       if (
@@ -252,8 +252,6 @@ export function mdxToJsx(mdx, processor) {
       ) {
         return shadowPosition - esmShadow.length - componentStart.length
       }
-
-      return 0
     }
   }
 }


### PR DESCRIPTION
MDX content is converted to JavaScript. TypeScript then uses this JavaScript handle requests. It then returns positional information that needs to be mapped back to the original MDX content.

This was previously not handled properly, leading to mostly false positive results. This is now handled better by stripping results that reference locations that can’t be mapped back to the original MDX content.

This was mostly tested manually. More tests are needed.