### PR TITLE
Skip completion in markdown content

### DIFF
--- a/.changeset/filter-completion.md
+++ b/.changeset/filter-completion.md
@@ -1,0 +1,5 @@
+---
+vscode-mdx: minor
+---
+
+Filter TypeScript based completions when writing markdown content.

--- a/fixtures/node16/completion.mdx
+++ b/fixtures/node16/completion.mdx
@@ -1,0 +1,9 @@
+export function exported() {
+  // Completion is supported in ESM
+}
+
+<div>
+  {/* Completion is supported in JSX */}
+</div>
+
+Completion is empty in markdown content.

--- a/packages/language-server/tests/completion.test.js
+++ b/packages/language-server/tests/completion.test.js
@@ -1,0 +1,94 @@
+/**
+ * @typedef {import('vscode-languageserver').ProtocolConnection} ProtocolConnection
+ */
+import assert from 'node:assert/strict'
+import {afterEach, beforeEach, test} from 'node:test'
+
+import {CompletionRequest, InitializeRequest} from 'vscode-languageserver'
+
+import {createConnection, fixtureUri, openTextDocument} from './utils.js'
+
+/** @type {ProtocolConnection} */
+let connection
+
+beforeEach(() => {
+  connection = createConnection()
+})
+
+afterEach(() => {
+  connection.dispose()
+})
+
+test('support completion in ESM', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/completion.mdx')
+  const result = await connection.sendRequest(CompletionRequest.type, {
+    position: {line: 1, character: 1},
+    textDocument: {uri}
+  })
+
+  assert.ok(result)
+  assert.ok('items' in result)
+  const completion = result.items.find((r) => r.insertText === 'Boolean')
+  assert.deepEqual(completion, {
+    data: {
+      offset: 30,
+      uri: fixtureUri('node16/completion.mdx')
+    },
+    insertText: 'Boolean',
+    kind: 6,
+    label: 'Boolean',
+    sortText: '15',
+    tags: []
+  })
+})
+
+test('support completion in JSX', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/completion.mdx')
+  const result = await connection.sendRequest(CompletionRequest.type, {
+    position: {line: 5, character: 3},
+    textDocument: {uri}
+  })
+
+  assert.ok(result)
+  assert.ok('items' in result)
+  const completion = result.items.find((r) => r.insertText === 'Boolean')
+  assert.deepEqual(completion, {
+    data: {
+      offset: 77,
+      uri: fixtureUri('node16/completion.mdx')
+    },
+    insertText: 'Boolean',
+    kind: 6,
+    label: 'Boolean',
+    sortText: '15',
+    tags: []
+  })
+})
+
+test('ignore completion in markdown content', async () => {
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {}
+  })
+
+  const {uri} = await openTextDocument(connection, 'node16/completion.mdx')
+  const result = await connection.sendRequest(CompletionRequest.type, {
+    position: {line: 8, character: 10},
+    textDocument: {uri}
+  })
+
+  assert.deepEqual(result, null)
+})

--- a/packages/language-service/lib/index.js
+++ b/packages/language-service/lib/index.js
@@ -542,6 +542,11 @@ export function createMdxLanguageService(ts, host, plugins) {
 
     getCompletionsAtPosition(fileName, position, options, formattingSettings) {
       const snapshot = syncSnapshot(fileName)
+
+      if (snapshot && !snapshot.isJavaScript(position)) {
+        return
+      }
+
       const completionInfo = ls.getCompletionsAtPosition(
         fileName,
         snapshot?.getShadowPosition(position) ?? position,

--- a/packages/language-service/lib/utils.js
+++ b/packages/language-service/lib/utils.js
@@ -18,6 +18,8 @@
  *   Map a position from the real MDX document to the JSX shadow document.
  * @property {(shadowPosition: number) => number | undefined} getRealPosition
  *   Map a position from the shadow document to the real MDX document.
+ * @property {(position: number) => boolean} isJavaScript
+ *   Check if a position maps to JavaScript or markdown content.
  * @property {unknown} [error]
  *   This is defined if a parsing error has occurred.
  * @property {Root} ast
@@ -140,7 +142,8 @@ export function mdxToJsx(mdx, processor) {
       getLength: () => fallback.length,
 
       getShadowPosition: () => undefined,
-      getRealPosition: () => undefined
+      getRealPosition: () => undefined,
+      isJavaScript: () => true
     }
   }
 
@@ -253,6 +256,11 @@ export function mdxToJsx(mdx, processor) {
       ) {
         return shadowPosition - esmShadow.length - componentStart.length
       }
+    },
+    isJavaScript(position) {
+      return (
+        shouldShow(esmPositions, position) || shouldShow(jsxPositions, position)
+      )
     }
   }
 }


### PR DESCRIPTION
TypeScript based completion is only relevant inside JavaScript based parts, such as ESM and JSX. It’s irrelevant and distracting when writing markdown sections.

This also adds missing tests for completion.